### PR TITLE
Fix capitalization in Gal 4:22

### DIFF
--- a/final-usfm/cth/48-Galatians.usfm
+++ b/final-usfm/cth/48-Galatians.usfm
@@ -141,7 +141,7 @@
 \s ~
 \p
 \v 21 Tell me, you who want to be still subject to Law — Why don't you listen to the Law?
-\v 22 scripture says that Abraham had two sons, one the child of the slave-woman and the other the child of the free woman.
+\v 22 Scripture says that Abraham had two sons, one the child of the slave-woman and the other the child of the free woman.
 \v 23 But the child of the slave-woman was born in the course of nature, while the child of the free woman was born in fulfilment of a promise.
 \v 24 This story may be taken as an allegory. The women stand for two Covenants. One covenant, given from Mount Sinai, produces a race of slaves and is represented by Hagar
 \v 25 (The word Hagar meaning in Arabia Mount Sinai) and it ranks with the Jerusalem of today, for she and her children are in slavery.

--- a/final-usfm/us/48-Galatians.usfm
+++ b/final-usfm/us/48-Galatians.usfm
@@ -141,7 +141,7 @@
 \s ~
 \p
 \v 21 Tell me, you who want to be still subject to Law — Why don't you listen to the Law?
-\v 22 scripture says that Abraham had two sons, one the child of the slave-woman and the other the child of the free woman.
+\v 22 Scripture says that Abraham had two sons, one the child of the slave-woman and the other the child of the free woman.
 \v 23 But the child of the slave-woman was born in the course of nature, while the child of the free woman was born in fulfillment of a promise.
 \v 24 This story may be taken as an allegory. The women stand for two Covenants. One covenant, given from Mount Sinai, produces a race of slaves and is represented by Hagar
 \v 25 (The word Hagar meaning in Arabia Mount Sinai) and it ranks with the Jerusalem of today, for she and her children are in slavery.

--- a/sources/tcnt/patches/00-punctuation/01 - capitalisation/scripture.patch
+++ b/sources/tcnt/patches/00-punctuation/01 - capitalisation/scripture.patch
@@ -134,8 +134,6 @@ In Galatians:
     3:13    Scripture  ->  scripture
     ; 22 But the words of Scripture represent the whole world as being in bondage to sin, so that the prom
     3:22    Scripture  ->  scripture
-    ; n to the Law? \v 22 Scripture says that Abraham had two sons, one the child of the slave-woman and t
-    4:22    Scripture  ->  scripture
     ; r mother. \v 27 For Scripture says — \q1 ‘Rejoice, thou barren one, who dost never bear,  \q1 Break 
     4:27    Scripture  ->  scripture
     ; does the passage of Scripture say?  \q ‘Send away the slave-woman and her son; for the slave's son s


### PR DESCRIPTION
The current form of Galatians 4:21-22 reads as "...Why don't you listen to the Law? scripture says that....".  The lowercase "scripture" appears to be the result an erroneous find-and-replace patch.