### PR TITLE
'For ever' should be 'forever' in US English

### DIFF
--- a/source/18-Job.usfm.db
+++ b/source/18-Job.usfm.db
@@ -586,7 +586,7 @@ of God and His Longing to be Gone
 \v 15 That gladly would I be strangled:
 \q2 Death itself I spurn in my pain.
 \q
-\v 16 I would not live for ever:
+\v 16 I would not live [us:forever|cth:for ever]:
 \q2 Let me go, for my days are but breath.
 \q
 \v 17 What is man, that so great Thou dost count him
@@ -1186,7 +1186,7 @@ of God and His Longing to be Gone
 \p
 \v 12a He lieth, to rise up no more.
 \q
-\v 20 Thou dost worst him for ever; he passeth,
+\v 20 Thou dost worst him [us:forever|cth:for ever]; he passeth,
 \q2 Dismissed – with his face how changed!
 \q
 \v 21 Honour comes to his sons, but he knows not:
@@ -1602,7 +1602,7 @@ of God and His Longing to be Gone
 \q2 That they were inscribed in a book,
 \q
 \v 24 That with iron pen and with lead
-\q2 On a rock they were graven for ever.
+\q2 On a rock they were graven [us:forever|cth:for ever].
 \q
 \v 25 I know that there liveth a Champion,
 \q2 Who will one day stand over my dust;
@@ -1950,7 +1950,7 @@ Earth have already Witnessed against Job
 \q2 Nay, He would give heed unto me.
 \q
 \v 7 There the upright might argue with Him,
-\q2 And my right I should rescue for ever.
+\q2 And my right I should rescue [us:forever|cth:for ever].
 \q
 \v 8 Behold, I go east, but He is not:
 \q2 And west, but I cannot perceive Him.
@@ -3595,7 +3595,7 @@ I am but young in years,
 \q2 Or will he speak softly to thee?
 \q
 \v 4 Will he make any tryst with thee,
-\q2 To be kept as thy servant for ever?
+\q2 To be kept as thy servant [us:forever|cth:for ever]?
 \q
 \v 5 Wilt thou play with him as with a bird,
 \q2 Or attach him to string for thy maidens?

--- a/source/19-Psalms.usfm.db
+++ b/source/19-Psalms.usfm.db
@@ -2783,7 +2783,7 @@
 \q2 pierced to the heart are the foes of the king.
 \b
 \q
-\v 6 Your throne shall endure for ever and ever
+\v 6 Your throne shall endure [us:forever|cth:for ever] and ever
 \q2 your royal sceptre a sceptre of equity.
 \q
 \v 7 Right you love and wrong you hate:
@@ -2821,7 +2821,7 @@
 \q2 whom you will make princes in all the land.
 \q
 \v 17 Your name will I celebrate world without end,
-\q2 so that nations shall praise you for ever and ever.
+\q2 so that nations shall praise you [us:forever|cth:for ever] and ever.
 
 \c 46
 \s Psalm 46 – Our God is a Mighty Fortress
@@ -2956,7 +2956,7 @@
 \q2
 \v 14 That such is God,
 \q our God he it is who shall guide us
-\q2 for ever and ever.
+\q2 [us:forever|cth:for ever] and ever.
 
 \c 49
 \s Psalm 49 – The Problem of the Prosperity of the Wicked
@@ -2988,7 +2988,7 @@
 \v 8 for the ransom of a life is costly,
 \q2 no payment is ever enough,
 \q
-\v 9 to keep [neut:them|masc:him] alive for ever and ever,
+\v 9 to keep [neut:them|masc:him] alive [us:forever|cth:for ever] and ever,
 \q2 so as never to see the pit at all.
 \b
 \q
@@ -2997,7 +2997,7 @@
 \q2 and abandon their wealth to others.
 \q
 \v 11 The grave is their everlasting home,
-\q2 the place they shall live in for ever and ever,
+\q2 the place they shall live in [us:forever|cth:for ever] and ever,
 \q2 though after their own names they called whole lands.
 \q
 \v 12 Despite their wealth,
@@ -3218,9 +3218,9 @@
 \v 8 But I am like a fresh olive-tree
 \q2 in the house of God.
 \q I trust in the kindness of God
-\q2 for ever and evermore.
+\q2 [us:forever|cth:for ever] and evermore.
 \q
-\v 9 I will render you thanks for ever
+\v 9 I will render you thanks [us:forever|cth:for ever]
 \q2 for what you have done.
 \q I will tell how good you are
 \q2 in the presence of those who love you.
@@ -5717,7 +5717,7 @@
 \v 36 “that his line should endure forever,
 \q2 and his throne as the sun before me,
 \q
-\v 37 firm as the moon which for ever
+\v 37 firm as the moon which [us:forever|cth:for ever]
 \q2 and ever is fixed in the sky.” \qs Selah\qs*
 \b
 \q
@@ -5772,7 +5772,7 @@
 \b
 \b
 \q3
-\v 52 \em Blest be the \+nd Lord\+nd*, for ever and ever.\em*
+\v 52 \em Blest be the \+nd Lord\+nd*, [us:forever|cth:for ever] and ever.\em*
 \q3 \em Amen and Amen.\em*
 
 \c 90
@@ -5981,7 +5981,7 @@
 \q
 \v 5 What you have ordained is most sure;
 \q2 most sure shall your house stand inviolate,
-\q2 O \nd Lord\nd*, for ever and ever.
+\q2 O \nd Lord\nd*, [us:forever|cth:for ever] and ever.
 
 \c 94
 \s Psalm 94 – A Prayer for Vengeance on the Cruel
@@ -7280,7 +7280,7 @@
 \b
 \q
 \v 4 The \nd Lord\nd* has sworn and will not repent,
-\q2 “As for you, you are priest for ever
+\q2 “As for you, you are priest [us:forever|cth:for ever]
 \q2 as Melchizedek was.”
 \b
 \q
@@ -7319,7 +7319,7 @@
 \v 7 All that he does is faithful and right,
 \q2 all his behests are firm and sure.
 \q
-\v 8 They are established for ever and ever,
+\v 8 They are established [us:forever|cth:for ever] and ever,
 \q2 executed with truth and uprightness.
 \q
 \v 9 To his people he sent redemption,
@@ -7328,7 +7328,7 @@
 \q2
 \v 10 The fear of the \nd Lord\nd* is the beginning of wisdom
 \q those who keep it are wise indeed.
-\q2 His praise abides for ever and ever.
+\q2 His praise abides [us:forever|cth:for ever] and ever.
 
 \c 112
 \s Psalm 112 – The Blessings of Godliness
@@ -7824,7 +7824,7 @@ Happy [neut:are those who fear|masc:the man who fears] the \nd Lord\nd*,
 \q2 for in your judgments I hope.
 \q
 \v 44 I will keep your law continually,
-\q2 for ever and evermore.
+\q2 [us:forever|cth:for ever] and evermore.
 \q
 \v 45 So shall I walk in wide spaces,
 \q2 for I give my mind to your precepts.
@@ -9286,10 +9286,10 @@ Happy [neut:are those who fear|masc:the man who fears] the \nd Lord\nd*,
 \d A song of praise. Of David.
 \q
 \v 1 I will exalt you, my God, O king:
-\q2 I will praise your name for ever and ever.
+\q2 I will praise your name [us:forever|cth:for ever] and ever.
 \q
 \v 2 I will bless you every day:
-\q2 I will praise your name for ever and ever.
+\q2 I will praise your name [us:forever|cth:for ever] and ever.
 \b
 \q
 \v 3 Great is the \nd Lord\nd* and worthy all praise,
@@ -9359,7 +9359,7 @@ Happy [neut:are those who fear|masc:the man who fears] the \nd Lord\nd*,
 \q
 \v 21 My mouth will utter the praise of the \nd Lord\nd*,
 \q2 and all life will bless his holy name
-\q3 for ever and ever.
+\q3 [us:forever|cth:for ever] and ever.
 
 \c 146
 \s Psalm 146 – The Great Protector
@@ -9494,7 +9494,7 @@ Happy [neut:are those who fear|masc:the man who fears] the \nd Lord\nd*,
 \v 5 Let them praise the name of the \nd Lord\nd*,
 \q2 for at his command they were made.
 \q
-\v 6 And he fixed them for ever and ever
+\v 6 And he fixed them [us:forever|cth:for ever] and ever
 \q2 by a law which they dare not transgress.
 \b
 \q

--- a/source/21-Ecclesiastes.usfm.db
+++ b/source/21-Ecclesiastes.usfm.db
@@ -32,7 +32,7 @@ king of Jerusalem.
 \v 7 All the rivers run into the sea,
 \q2 But nevertheless is the sea not full.
 \q To the place to which the rivers run,
-\q2 Thither they run and run for ever.
+\q2 Thither they run and run [us:forever|cth:for ever].
 \q
 \v 8 All things are full or weariness,
 \q2 Of weariness unutterable,

--- a/source/23-Isaiah.usfm.db
+++ b/source/23-Isaiah.usfm.db
@@ -355,7 +355,7 @@
 \v 16 Moreover the \nd Lord\nd* said:
 \q2 “Because Zion's daughters are haughty,
 \q walking with heads held high,
-\q2 and eyes for ever ogling,
+\q2 and eyes [us:forever|cth:for ever] ogling,
 \q with dainty little steps,
 \q2 and anklets ever jingling,
 \q
@@ -872,7 +872,7 @@
 \b
 \q To establish and uphold it
 \q2 in the righteousness and justice
-\q from henceforth and for ever.
+\q from henceforth and [us:forever|cth:for ever].
 \q2 The zeal of the \nd Lord\nd* of Hosts
 \q2 shall bring this thing to pass.
 
@@ -1326,7 +1326,7 @@
 \q2 to which God hurled Gomorrah and Sodom.
 \b
 \q
-\v 20 For ever shall she be desolate,
+\v 20 [us:Forever|cth:For ever] shall she be desolate,
 \q2 tenantless age after age.
 \q No Arab shall pitch his tent there,
 \q2 no shepherd shall fold his flock there;
@@ -1630,7 +1630,7 @@
 \p
 \v 1 Oracle on Damascus
 \q See! soon shall Damascus no more be a city,
-\q2 but only ruin, forsaken for ever.
+\q2 but only ruin, forsaken [us:forever|cth:for ever].
 \q
 \v 2 To the grazing of flocks shall her cities be given,
 \q2 and there shall they lie, with not one to affright them.
@@ -2279,8 +2279,8 @@
 \v 7 He shall rend on this mountain the veil
 \q2 that enwrapped the face of all nations.
 \q
-\v 8 He will swallow up death for ever.
-\q And then will swallow up death for ever.
+\v 8 He will swallow up death [us:forever|cth:for ever].
+\q And then will swallow up death [us:forever|cth:for ever].
 \q And then will the Lord the \nd Lord\nd*
 \q2 Wipe tears from every face,
 \q and remove from off the earth
@@ -2330,7 +2330,7 @@
 \v 2 You have made of a city a heap,
 \q2 of a fortified city a ruin;
 \q the palace of pride is a city no more,
-\q2 it shall not be rebuilt for ever.
+\q2 it shall not be rebuilt [us:forever|cth:for ever].
 \q
 \v 3 For this shall fierce nations own Your glory,
 \q2 the city of tyrants shall fear You.
@@ -2398,7 +2398,7 @@
 \v 8 We have looked for You, O the \nd Lord\nd*,
 \q2 to come by Your pathway of judgment;
 \q we have yearned for a sign of Your presence,
-\q2 which men may remember for ever.
+\q2 which men may remember [us:forever|cth:for ever].
 \q
 \v 9 I have yearned for You in the night,
 \q2 yea, with passionate spirit have sought You.
@@ -2643,7 +2643,7 @@
 \v 23 Listen, and hear you my voice;
 \q2 attend and give ear to my speech.
 \q
-\v 24 Doth the ploughman keep ploughing for ever,
+\v 24 Doth the ploughman keep ploughing [us:forever|cth:for ever],
 \q2 keep opening and harrowing his ground?
 \q
 \v 25 Doth he not, after levelling its surface,
@@ -2661,7 +2661,7 @@
 \q2 and cummin with a flail.
 \q
 \v 28 Do we ever crush bread-corn to pieces?
-\q2 Nay, we do not keep threshing for ever;
+\q2 Nay, we do not keep threshing [us:forever|cth:for ever];
 
 \ms2 The Character and Fate Jerusalem
 
@@ -2837,7 +2837,7 @@
 \v 8 Now go and write it down,
 \q2 and on a roll inscribe it,
 \q that it may be for the after-time,
-\q2 a testimony for ever.
+\q2 a testimony [us:forever|cth:for ever].
 \q
 \v 9 For a rebel people are they,
 \q2 sons that are utterly false,
@@ -3069,7 +3069,7 @@
 \q2 No more shall a knave be named ‟princely.”
 \b
 \q
-\v 6 For the fool speaks folly for ever,
+\v 6 For the fool speaks folly [us:forever|cth:for ever],
 \q2 his mind evermore plots mischief;
 \q his doings are profane,
 \q2 and error he speaks of the \nd Lord\nd*.
@@ -3127,7 +3127,7 @@
 \q
 \v 17 Of justice the fruit shall be peace,
 \q2 and the outcome of righteousness safety
-\q2 and quietness for ever.
+\q2 and quietness [us:forever|cth:for ever].
 \q
 \v 18 My people shall dwell in the mansion of peace,
 \q2 at the easeful rest in abodes secure.
@@ -3316,10 +3316,10 @@
 \q2 that burns night and day.
 \b
 \q
-\v 10 It shall not be quenched for ever,
+\v 10 It shall not be quenched [us:forever|cth:for ever],
 \q2 her smoke shall go up through the ages;
 \q a waste she shall lie evermore,
-\q2 to be crossed by no traveller for ever –
+\q2 to be crossed by no traveller [us:forever|cth:for ever] –
 \b
 \q
 \v 11 The haunt of the pelican and bittern,
@@ -3713,7 +3713,7 @@
 \q2 when upon it the breath of the \nd Lord\nd* has blown.
 \q
 \v 8 Yea, the grass withers, the flower fades;
-\q2 but the word of our God shall stand for ever.”
+\q2 but the word of our God shall stand [us:forever|cth:for ever].”
 \b
 \q
 \v 9 Get you up to a mountain high,
@@ -4512,7 +4512,7 @@
 \v 17 But Israel is saved by the \nd Lord\nd*
 \q2 With salvation everlasting:
 \q You shall not be ashamed or confounded
-\q2 for ever and evermore.
+\q2 [us:forever|cth:for ever] and evermore.
 
 \ms2 The Lord Desires the Salvation of the Whole World
 \q
@@ -4669,7 +4669,7 @@
 \q you laid upon the aged
 \q2 thine exceeding heavy yoke.
 \q
-\v 7 You said, ‟I shall live for ever,
+\v 7 You said, ‟I shall live [us:forever|cth:for ever],
 \q2 and be Mistress evermore;”
 \q These things you did lay not heart,
 \q2 nor did think how it all would end.
@@ -4868,7 +4868,7 @@
 \q2 but never will I forget you.
 \q
 \v 16 I have graven you on My hands,
-\q2 and your walls are for ever before Me:
+\q2 and your walls are [us:forever|cth:for ever] before Me:
 \q
 \v 17 In haste men are coming to build you;
 \q2 while those that have torn you down
@@ -5637,14 +5637,14 @@
 \q2 take the stumbling-blocks out of the way of My people.
 \q
 \v 15 For thus says He that is high and exalted,
-\q2 whose throne is for ever, whose name is Holy:
+\q2 whose throne is [us:forever|cth:for ever], whose name is Holy:
 \q “On high as the Holy One sit I enthroned,
 \q2 and with him that is crushed, that is lowly in spirit;
 \q to quicken the spirit of them that are lowly,
 \q2 and the heart of all such as crushed to revive.
 \b
 \q
-\v 16 For not for ever will I contend,
+\v 16 For not [us:forever|cth:for ever] will I contend,
 \q2 nor cherish Mine anger evermore;
 \q for then would the spirits faint before Me,
 \q2 the souls that I Myself have made.
@@ -5989,7 +5989,7 @@
 \b
 \q
 \v 21 Your people shall all be righteous,
-\q2 possessing the land for ever,
+\q2 possessing the land [us:forever|cth:for ever],
 \q the shoot of the \nd Lord\nd*'s planting,
 \q2 the work of His hands, for His glory.
 \q
@@ -6293,7 +6293,7 @@
 \q2 the work of Your hand are we all.
 \q
 \v 9 O be not, the \nd Lord\nd*, exceeding wroth,
-\q2 and do not remember our guilt for ever.
+\q2 and do not remember our guilt [us:forever|cth:for ever].
 \q Behold, look, we beseech You,
 \q2 for we are all Your people.
 \b
@@ -6344,7 +6344,7 @@
 \v 5 That say, “Keep by yourself,
 \q2 keep away from me, lest I infect you.”
 \q Such men are a smoke in My nostrils,
-\q2 a fire that blazes for ever.
+\q2 a fire that blazes [us:forever|cth:for ever].
 \q
 \v 6 Behold, it is written before Me:
 \q2 I will not, says the \nd Lord\nd*, keep silence,
@@ -6420,7 +6420,7 @@
 \q The past shall not be remembered,
 \q2 nor come into mind again;
 \q
-\v 18 But men shall for ever rejoice and exult
+\v 18 But men shall [us:forever|cth:for ever] rejoice and exult
 \q2 over this My (new) creation.
 \q For behold! I will straightway create
 \q2 jerusalem a rejoicing,

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -358,7 +358,7 @@ Voice). "A boiling pot," I answered, "facing the
 \v 4 Yet but now has been calling Me Father
 \q2 And Comrade of thy youth.
 \q
-\v 5 "Can He keep His anger for ever,
+\v 5 "Can He keep His anger [us:forever|cth:for ever],
 \q2 Or cherished it to the end?
 \q Yes, such were thy words; but they deeds
 \q2 To the last degree were vile.
@@ -395,7 +395,7 @@ proclaim these words towards the north and say:
 O backsliding Israel, turn,
 \q2 I will not look in anger upon thee;
 \q For I am kind, saith Jehovah,
-\q2 I keep not Mine anger for ever.
+\q2 I keep not Mine anger [us:forever|cth:for ever].
 \q
 \v 13 But only acknowledge thy guilt–
 \q2 That, disloyal to Jehovah thy God,
@@ -852,7 +852,7 @@ your forefathers for an inheritance.
 \v 7 As a well keepeth fresh her waters,
 \q2 She keepeth her wickedness fresh;
 \q Within her are rapine and violence heard,
-\q2 Sickness and wounds are for ever before Me.
+\q2 Sickness and wounds are [us:forever|cth:for ever] before Me.
 \q
 \v 8 O Jerusalem, be admonished,
 \q2 Lest My soul from thee be severed,
@@ -1148,7 +1148,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 And one who hath wandered turn back again?
 \q
 \v 5 Why, then, doth thy people keep turning
-\q2 For ever and ever backward,
+\q2 [us:Forever|cth:For ever] and ever backward,
 \q Clinging to ways deceitful,
 \q2 Refusing to return?
 \q
@@ -2309,7 +2309,7 @@ other gods; for no favour shall ye have from Me."
 \q I will make thee the slave of thy foes
 \q2 In a land that is strange to thee;
 \q For a fire in Mine anger is kindled
-\q2 That burneth for ever.
+\q2 That burneth [us:forever|cth:for ever].
 
 
 \ms2 The Joy and Wisdom of Trust
@@ -2330,7 +2330,7 @@ other gods; for no favour shall ye have from Me."
 \v 8 Like a tree shall he be, by the waters planted,
 \q2 That stretcheth its roots out towards the stream,
 \q And is never afraid for the coming of heat,
-\q2 But its leaves are for ever green–
+\q2 But its leaves are [us:forever|cth:for ever] green–
 \q In the year of drought untroubled–
 \q2 And it yeildeth fruit without ceasing.
 \q
@@ -2416,7 +2416,7 @@ Sabbath day, if you keep the Sabbath day holy and
 sit upon the throne of David shall enter the gates of
 this city riding on chariots and horses, accompanied
 by their princes, the men of Judah, and the citizens of
-Jerusalem; and the city shall be inhabited for ever.
+Jerusalem; and the city shall be inhabited [us:forever|cth:for ever].
 \v 26 From the cities of Judah, the neighbourhood of
 Jerusalem, and the district of Benjamin, from the low-
 land, the hill country, and the south, men shall come
@@ -2719,7 +2719,7 @@ and all the friends to whom thou hast prophesied lies."
 \q
 \v 17 That he slew me not in the womb,
 \q2 So my mother had been my grave,
-\q And her womb had been great for ever.
+\q And her womb had been great [us:forever|cth:for ever].
 \p
 \v 18 O why came I forth from the womb
 \q To behold but labour and sorrow,
@@ -3221,7 +3221,7 @@ been sending to you all His servants the prophets,
 through you have not listened nor inclined an attentive
 \v 5 ear. My message was this: "If you abandon, every
 man of you, your wicked ways and your evil behaviour,
-then you shall dwell for ever in the land which Jehovah,
+then you shall dwell [us:forever|cth:for ever] in the land which Jehovah,
 gave in the ancient time to you and your forefathers.
 \v 6 But do not indulge in the worship or service of other
 gods, and do not provoke Jehovah with the fabri-
@@ -3239,7 +3239,7 @@ fetch a clan from the north, and I will bring them
 against this land and its inhabitants and against the
 sorrounding nation. I will devote them to destruc-
 tion so appalling that men shall hiss and revile them
-\v 10 for ever; and I will banish form them the voice of mirth
+\v 10 [us:forever|cth:for ever]; and I will banish form them the voice of mirth
 and gladness, the voice of bridegroom and bride, the
 sound of the millstones and the light of the lamp.
 \v 11 This whole land shall be a waste and a horror, and
@@ -3249,7 +3249,7 @@ years.
 \v 12 When, however, seventy years are completed, I will punish
 the king of Babylon, and that nation, saith Jehovah, for their
 guilt, and also the land of the Chaldeans, which I will make
-\v 13 desolate for ever; and I will bring upon that land all the words
+\v 13 desolate [us:forever|cth:for ever]; and I will bring upon that land all the words
 I have pronounced against it – everything prophesied by
 Jeremiah against all the nations, that is recorded in this Book.
 \v 14 They, yes they, shall be reduced to slavery at the hands of
@@ -4057,7 +4057,7 @@ forefathers.
 \v 36 Not until those fixed orbs shall vanish
 \q2 Clean out of My sight, saith Jehovah,
 \q Shall Israel's race cease to be
-\q2 A nation before Me for ever.
+\q2 A nation before Me [us:forever|cth:for ever].
 \q
 \v 37 Not till the heavens above can be measured,
 \q2 And earth's foundations be searched out beneath,
@@ -4080,7 +4080,7 @@ valley (of Hinnom) with its corpses and ashes and
 the whole locality as far as the valley of Kidron up
 to the corner of the horse-gate on the east, shall be
 consecrated to Jehovah; it shall not be plucked up or
-thrown down again for ever.
+thrown down again [us:forever|cth:for ever].
 
 
 
@@ -4236,7 +4236,7 @@ bring them back to this place and settle them here
 \v 38 securely; and they shall be My people, and I will be
 \v 39 their God. A single heart I will give them, and a single
 way (will I set before them), that they may hold Me
-in reverence for ever, and that they and their children
+in reverence [us:forever|cth:for ever], and that they and their children
 \v 40 after them may prosper; and I will make with them
 an everlasting covenant to follow them ceaselessly
 with My blessing, and I will put the fear of Me in their
@@ -4306,7 +4306,7 @@ bridegroom and bride, the voice of those that say, as they
 bring their thank-offerings into the House of Jehovah,
 \q2 Give thanks to Jehovah of Hosts,
 \q2 For Jehovah is gracious,
-\q2 His kindness endureth for ever.
+\q2 His kindness endureth [us:forever|cth:for ever].
 For I will restore the fortunes of the land, saith
 \v 12 Jehovah, as in the olden time. Thus saith Jehovah of
 Hosts: In this place which is desolate, forsaken of
@@ -4496,7 +4496,7 @@ Maaseiah, the son of Shallum, the Keeper of the
 they said, "we will drink no wine; for Jonadab, the
 son of Rechab, our ancestor, laid a charge upon us and
 \v 7 our children to drink no wine, to build no houses, to sow
-no seed, to plant and possess no vineyard for ever, but to
+no seed, to plant and possess no vineyard [us:forever|cth:for ever], but to
 spend all our days in tents, so that we might live long on
 \v 8 the land where as strangers we dwell. In full obedience,
 therefore, to this charge of Jonadab, the son of Rechab,
@@ -6486,7 +6486,7 @@ the prophet.
 \q
 \v 39 So wild cats and wolves shall dwell there,
 \q2 And there shall ostriches dwell;
-\q She shall not be re-peopled for ever,
+\q She shall not be re-peopled [us:forever|cth:for ever],
 \q2 Or dwelt in through all generations.
 \q
 \v 40 As when Sodom was overthrown,
@@ -6842,7 +6842,7 @@ he said to Seraiah, "When you arrive at Babylon, see
 Jehovah, are these words; it is Thou that hast decreed
 the destruction of this place – that never again shall it
 be a home for man or beast, but that it shall remain a
-\v 63 desolation for ever.' When you have finished reading
+\v 63 desolation [us:forever|cth:for ever].' When you have finished reading
 this scroll, tie a stone to it and throw it into the middle
 \v 64 of the Euphrates, with the words: 'Thus shall Babylon
 sink, to rise no more, because of all the misery that I

--- a/source/25-Lamentations.usfm.db
+++ b/source/25-Lamentations.usfm.db
@@ -398,7 +398,7 @@
 \v 19 The thought of my woe and my wandering
 \q2 Is wormwood and gall.
 \q
-\v 20 My soul doth for ever recall them,
+\v 20 My soul doth [us:forever|cth:for ever] recall them,
 \q2 And is bowed down within me.
 \q
 \v 21 Now this I will lay on my heart
@@ -432,7 +432,7 @@
 \q2 And bear all the taunt.
 \q
 \v 31 For Jehovah will not cast away
-\q2 The afflicted for ever.
+\q2 The afflicted [us:forever|cth:for ever].
 \q
 \v 32 Though He wound, He will yet have compassion–
 \q2 His love is so great.
@@ -622,7 +622,7 @@
 \v 15 "Away, ye unclean!" – men adjure them–
 \q2 "Away, touch us not!"
 \q So they stagger and wander around
-\q2 With no resting for ever.
+\q2 With no resting [us:forever|cth:for ever].
 \q
 \v 16 Jehovah Himself hath dispersed them–
 \q2 He careth no more.
@@ -726,10 +726,10 @@
 
 \s Prayer for Deliverance
 \q
-\v 19 But thou, Lord, art seated for ever,
+\v 19 But thou, Lord, art seated [us:forever|cth:for ever],
 \q2 From age to age, on Thy throne.
 \q
-\v 20 O why then forget us for ever,
+\v 20 O why then forget us [us:forever|cth:for ever],
 \q2 And leave us for long, long days?
 \q
 \v 21 Bring us back to Thee, Lord, let us turn,

--- a/source/27-Daniel.usfm.db
+++ b/source/27-Daniel.usfm.db
@@ -397,7 +397,7 @@
 \v 15 As for me, Daniel, my spirit was grieved by reason of this, and the visions of my head troubled me.
 \v 16 I came near to one of those who stood by, and asked him the truth concerning all this. So he told me the interpretation of the things:
 \v 17 “These four great beasts are four kings who will arise out of the earth.
-\v 18 But the holy ones of the Most High will receive the sovereignty, and possess the sovereignty for ever, for ever and ever.
+\v 18 But the holy ones of the Most High will receive the sovereignty, and possess the sovereignty [us:forever|cth:for ever], [us:forever|cth:for ever] and ever.
 
 \p
 \v 19 Then I desired to know the truth concerning the fourth beast, which was different from all of them, exceedingly terrible, whose teeth were of iron, and its nails of bronze; which devoured, broke in pieces, and stamped the rest with its feet:

--- a/source/42-Luke.usfm.db
+++ b/source/42-Luke.usfm.db
@@ -66,7 +66,7 @@
 \v 30 when the angel spoke again, “Do not be afraid, Mary, for you have found [us:favor|cth:favour] with God.
 \v 31 And now, you will conceive and give birth to a son, and you will give him the name Jesus.
 \v 32 The child will be great and will be called ‘Son of the Most High,’ and the Lord God will give him the throne of his ancestor David,
-\v 33 and he will reign over the descendants of Jacob for ever; And to his kingdom there will be no end.”
+\v 33 and he will reign over the descendants of Jacob [us:forever|cth:for ever]; And to his kingdom there will be no end.”
 \p
 \v 34 “How can this be?” Mary asked the angel. “For I have no husband.”
 \p
@@ -114,7 +114,7 @@
 \q2 ever mindful of his mercy,
 \q1
 \v 55 as he promised to our ancestors
-\q2 for Abraham and his descendants for ever.”
+\q2 for Abraham and his descendants [us:forever|cth:for ever].”
 \m
 \v 56 Mary stayed with Elizabeth about three months, and then returned to her home.
 \v 57 When Elizabeth's time came, she gave birth to a son;

--- a/source/43-John.usfm.db
+++ b/source/43-John.usfm.db
@@ -436,7 +436,7 @@
 \v 48 \wj I am the life-giving bread.\wj*
 \v 49 \wj Your ancestors ate the manna in the desert, and yet died.\wj*
 \v 50 \wj The bread that comes down from heaven is such that whoever eats of it will never die.\wj*
-\v 51 \wj I am the living bread that has come down from heaven. If anyone eats of this bread, [neut:they|masc:he] will live for ever; and the bread that I will give is my flesh, which I will give for the life of the world.”\wj*
+\v 51 \wj I am the living bread that has come down from heaven. If anyone eats of this bread, [neut:they|masc:he] will live [us:forever|cth:for ever]; and the bread that I will give is my flesh, which I will give for the life of the world.”\wj*
 \p
 \v 52 [ioudaioi:They|jew:The Jews] began disputing with one another, “How is it possible for this man to give us his flesh to eat?”
 \p
@@ -445,7 +445,7 @@
 \v 55 \wj For my flesh is true food, and my blood true drink.\wj*
 \v 56 \wj [neut:Everyone who takes my flesh for their food, and drinks my blood, remains united to me, and I to them|masc:He who takes my flesh for his food, and drinks my blood, remains united to me, and I to him].\wj*
 \v 57 \wj As the living Father sent me as his messenger, and as I live because the Father lives, so [neut:the person who takes me for their|masc:he who takes me for his] food will live because I live.\wj*
-\v 58 \wj That is the bread which has come down from heaven – not such as your ancestors ate, and yet died; [neut:the person who takes this bread for their|masc:he who takes this bread for his] food will live for ever.”\wj*
+\v 58 \wj That is the bread which has come down from heaven – not such as your ancestors ate, and yet died; [neut:the person who takes this bread for their|masc:he who takes this bread for his] food will live [us:forever|cth:for ever].”\wj*
 \p
 \v 59 All this Jesus said in a synagogue, when he was teaching in Capernaum.
 \v 60 On hearing it, many of his disciples said, “This is harsh doctrine! Who can bear to listen to it?”
@@ -850,7 +850,7 @@
 \v 31 \wj Now this world is on its trial. Now the Spirit that is ruling this world will be driven out;\wj*
 \v 32 \wj and I, when I am lifted up from the earth, will draw all [neut:people|masc:men] to myself.”\wj*
 \v 33 By these words he indicated what death he was destined to die.
-\v 34 “We,” replied the people, “have learned from the Law that the Christ is to remain for ever; how is it, then, that you say that the Son of Man must be \wj ‘lifted up’\wj* Who is this ‘Son of Man’?”
+\v 34 “We,” replied the people, “have learned from the Law that the Christ is to remain [us:forever|cth:for ever]; how is it, then, that you say that the Son of Man must be \wj ‘lifted up’\wj* Who is this ‘Son of Man’?”
 \p
 \v 35 \wj “Only a little while longer,”\wj* answered Jesus, \wj “will you have the light among you. Travel on while you have the light, so that darkness may not overtake you; he who travels in the darkness does not know where he is going.\wj*
 \v 36 \wj While you still have the light, believe in the light, so that you may be [neut:children|masc:sons] of light.”\wj* After he had said this, Jesus went away, and hid himself from them.

--- a/source/44-Acts.usfm.db
+++ b/source/44-Acts.usfm.db
@@ -405,7 +405,7 @@
 \q3
 \v 50 Was it not my hand that made all these things?’
 \m
-\v 51 Stubborn people, heathen in heart and ears, you are for ever resisting the Holy Spirit; your ancestors did it, and you are doing it still.
+\v 51 Stubborn people, heathen in heart and ears, you are [us:forever|cth:for ever] resisting the Holy Spirit; your ancestors did it, and you are doing it still.
 \v 52 Which of the prophets escaped persecution at their hands? They killed those who foretold the coming of the righteous one; of whom you, in your turn, have now become the betrayers and murderers –
 \v 53 You who received the Law as transmitted by angels and yet failed to keep it.”
 \p

--- a/source/45-Romans.usfm.db
+++ b/source/45-Romans.usfm.db
@@ -49,13 +49,13 @@
 \p
 \v 18 So, too, there is a revelation from heaven of the divine wrath against every form of ungodliness and wickedness on the part of those [neut:people|masc:men] who, by their wicked lives, are stifling the truth.
 \v 19 This is so, because what can be known about God is plain to them; for God himself has made it plain.
-\v 20 For ever since the creation of the universe God's invisible attributes – his everlasting power and divinity – are to be seen and studied in his works, so that [neut:people|masc:men] have no excuse;
+\v 20 [us:Forever|cth:For ever] since the creation of the universe God's invisible attributes – his everlasting power and divinity – are to be seen and studied in his works, so that [neut:people|masc:men] have no excuse;
 \v 21 because, although they learned to know God, yet they did not offer him as God either praise or thanksgiving. Their speculations about him proved futile, and their undiscerning minds were darkened.
 \v 22 Professing to be wise, they showed themselves fools;
 \v 23 and they transformed the glory of the immortal God into the likeness of mortal [neut:humans|masc:man], and of birds, and beasts, and reptiles.
 \p
 \v 24 Therefore God abandoned them to impurity, letting them follow the cravings of their hearts, until they [us:dishonored|cth:dishonoured] their own bodies;
-\v 25 for they had substituted a lie for the truth about God, and had reverenced and worshiped created things more than the Creator, who is to be praised for ever. Amen.
+\v 25 for they had substituted a lie for the truth about God, and had reverenced and worshiped created things more than the Creator, who is to be praised [us:forever|cth:for ever]. Amen.
 \v 26 That, I say, is why God abandoned them to degrading passions. Even the women among them perverted the natural use of their bodies to the unnatural;
 \v 27 while the men, disregarding that for which women were intended by nature, were consumed with passion for one another. Men indulged in vile practices with men, and incurred in their own persons the inevitable penalty for their perverseness.
 \p
@@ -319,7 +319,7 @@
 \v 2 bears me out when I say that there is a great weight of sorrow on me and that my heart is never free from pain.
 \v 3 I could wish that I were myself accursed and severed from the Christ, for the sake of my [neut:people – my own flesh and blood|masc:brothers – my own countrymen].
 \v 4 For they are Israelites, and theirs are the adoption as sons, the visible presence, the Covenants, the revealed Law, the Temple worship, and the Promises.
-\v 5 They are descended from the Patriarchs; and, as far as his human nature was concerned, from them came the Christ – he who is supreme over all things, God for ever blessed. Amen.
+\v 5 They are descended from the Patriarchs; and, as far as his human nature was concerned, from them came the Christ – he who is supreme over all things, God [us:forever|cth:for ever] blessed. Amen.
 \p
 \v 6 Not that God's Word has failed. For it is not all who are descended from Israel who are true Israelites;
 \v 7 nor, because they are Abraham's descendants, are they all his children; but – ‘It is Isaac's children who will be called your descendants.’
@@ -414,7 +414,7 @@
 \v 33 Oh! The unfathomable wisdom and knowledge of God! How inscrutable are his judgments, how untraceable his ways! Yes –
 \v 34 Who has ever comprehended the mind of the Lord? Who has ever become his counsellor?
 \v 35 Or who has first given to him, so that he may claim a reward?
-\v 36 For all things are from him, through him, and for him. And to him be all glory for ever and ever! Amen.
+\v 36 For all things are from him, through him, and for him. And to him be all glory [us:forever|cth:for ever] and ever! Amen.
 \c 12
 \s Advice on Daily Life
 \p
@@ -558,4 +558,4 @@
 \p
 \v 25 Now to him who is able to strengthen you, as promised in the good news entrusted to me and in the proclamation of Jesus Christ, in accordance with the revelation of that hidden purpose, which in past ages was kept secret but now has been revealed
 \v 26 and, in obedience to the command of the immortal God, made known through the writings of the prophets to all nations, to secure submission to the faith –
-\v 27 to him, I say, the wise and only God, be ascribed, through Jesus Christ, all glory for ever and ever. Amen.
+\v 27 to him, I say, the wise and only God, be ascribed, through Jesus Christ, all glory [us:forever|cth:for ever] and ever. Amen.

--- a/source/47-2 Corinthians.usfm.db
+++ b/source/47-2 Corinthians.usfm.db
@@ -248,7 +248,7 @@
 \v 7 Let everyone give as he has determined before hand, not grudgingly or under compulsion; for God loves a cheerful giver.
 \v 8 God has power to shower all kinds of blessings on you, so that, having, under all circumstances and on all occasions, all that you can need, you may be able to shower all kinds of benefits on others.
 \v 9 (As scripture says –
-\q ‘He scattered broadcast, he gave to the poor; His righteousness continues for ever.’
+\q ‘He scattered broadcast, he gave to the poor; His righteousness continues [us:forever|cth:for ever].’
 \m
 \v 10 And he who supplies seed to the sower, and bread for eating, will supply you with seed, and cause it to increase, and will multiply the fruits of your righteousness).
 \v 11 Rich in all things yourselves, you will be able to show liberality to all, which, with our help, will cause thanksgiving to be offered to God.
@@ -316,7 +316,7 @@
 \v 28 And, not to speak of other things, there is my daily burden of anxiety about all the churches.
 \v 29 Who is weak without my being weak? Who is led astray without my burning with indignation?
 \v 30 If I must boast, I will boast of things which show my weakness!
-\v 31 The God and Father of the Lord Jesus – he who is for ever blessed – knows that I am speaking the truth.
+\v 31 The God and Father of the Lord Jesus – he who is [us:forever|cth:for ever] blessed – knows that I am speaking the truth.
 \v 32 When I was in Damascus, the Governor under King Aretas had the gates of that city guarded, so as to arrest me,
 \v 33 but I was let down in a basket through a window in the wall, and so escaped his hands.
 \c 12

--- a/source/48-Galatians.usfm.db
+++ b/source/48-Galatians.usfm.db
@@ -26,7 +26,7 @@
 \v 2 and from all the [neut:followers of the Lord|masc:brothers] here.
 \v 3 May God, our Father, and the Lord Jesus Christ, bless you and give you peace. For Christ, to rescue us from this present wicked age,
 \v 4 gave himself for our sins, in accordance with the will of God and Father,
-\v 5 to whom be ascribed all glory for ever and ever. Amen.
+\v 5 to whom be ascribed all glory [us:forever|cth:for ever] and ever. Amen.
 \rem Titleless Section Break
 \b
 \p

--- a/source/52-1 Thessalonians.usfm.db
+++ b/source/52-1 Thessalonians.usfm.db
@@ -101,7 +101,7 @@ Yet, [neut:friends|masc:brothers], we beg you to do even more.
 \v 14 For, as we believe that Jesus died and rose again, so also we believe that God will bring, with Jesus, those who through him have passed to their rest.
 \v 15 This we tell you on the authority of the Lord – that those of us who are still living at the coming of the Lord will not anticipate those who have passed to their rest.
 \v 16 For, with a loud summons, with the shout of an archangel, and with the trumpet-call of God, the Lord himself will come down from heaven.
-\v 17 Then those who died in union with Christ will rise first; and [us:afterward|cth:afterwards] we who are still living will be caught up in the clouds, with them, to meet the Lord in the air; and so we will be for ever with the Lord.
+\v 17 Then those who died in union with Christ will rise first; and [us:afterward|cth:afterwards] we who are still living will be caught up in the clouds, with them, to meet the Lord in the air; and so we will be [us:forever|cth:for ever] with the Lord.
 \v 18 Therefore, comfort one another with what I have told you.
 \c 5
 \p

--- a/source/54-1 Timothy.usfm.db
+++ b/source/54-1 Timothy.usfm.db
@@ -42,7 +42,7 @@
 \v 14 and the loving kindness of our Lord was boundless, and filled me with that faith and love which come from union with Christ Jesus.
 \v 15 How true the saying is, and worthy of the fullest acceptance, that ‘Christ Jesus came into the world to save sinners’! And there is no greater sinner than I!
 \v 16 Yet mercy was shown me for the express purpose that Christ Jesus might exhibit in my case, beyond all others, his exhaustless patience, as an example for those who were [us:afterward|cth:afterwards] to believe on him and attain eternal life.
-\v 17 To the eternal King, ever-living, invisible, the one God, be ascribed [us:honor|cth:honour] and glory for ever and ever. Amen.
+\v 17 To the eternal King, ever-living, invisible, the one God, be ascribed [us:honor|cth:honour] and glory [us:forever|cth:for ever] and ever. Amen.
 \p
 \v 18 This, then, is the charge that I lay on you, Timothy, my child, in accordance with what was predicted of you – Fight the good fight in the spirit of those predictions,
 \v 19 with faith, and with a clear conscience; and it is because they have thrust this aside, that, as regards the faith, some have wrecked their lives.
@@ -172,7 +172,7 @@ Those are the things to insist on in your teaching.
 \v 13 I beg you, as in the sight of God, the source of all life, and of Christ Jesus who before Pontius Pilate made the great profession of faith –
 \v 14 I implore you to keep his command free from stain or reproach, until the appearing of our Lord Jesus Christ.
 \v 15 This will be brought about in his own time by the one ever-blessed Potentate, the king of all kings and Lord of all lords,
-\v 16 who alone is possessed of immortality and dwells in unapproachable light, whom no [neut:one|masc:man] has ever seen or ever can see – to whom be ascribed [us:honor|cth:honour] and power for ever. Amen.
+\v 16 who alone is possessed of immortality and dwells in unapproachable light, whom no [neut:one|masc:man] has ever seen or ever can see – to whom be ascribed [us:honor|cth:honour] and power [us:forever|cth:for ever]. Amen.
 \p
 \v 17 Teach those who are wealthy in this life not to pride themselves, or fix their hopes, on so uncertain a thing as wealth, but on God, who gives us a wealth of enjoyment on every side.
 \v 18 Teach them to show kindness, to exhibit a wealth of good actions, to be open-handed and generous,

--- a/source/55-2 Timothy.usfm.db
+++ b/source/55-2 Timothy.usfm.db
@@ -121,7 +121,7 @@
 \v 15 You must also on your guard against him, for he is strongly opposed to our teaching.
 \v 16 At my first trial no one stood by me. They all deserted me. May it never be counted against them!
 \v 17 But the Lord came to my help and strengthened me, in order that, through me, the proclamation should be made so widely that all the Gentiles should hear it; and I was rescued out of the lion's mouth.
-\v 18 The Lord will rescue me from all evil, and bring me safe into his Heavenly kingdom. All glory to him for ever and ever! Amen.
+\v 18 The Lord will rescue me from all evil, and bring me safe into his Heavenly kingdom. All glory to him [us:forever|cth:for ever] and ever! Amen.
 \rem Titleless Section Break
 \b
 \p

--- a/source/57-Philemon.usfm.db
+++ b/source/57-Philemon.usfm.db
@@ -39,7 +39,7 @@
 \v 12 and I am sending him back to you with this letter – though it is like tearing out of my heart.
 \v 13 For my own sake I should like to keep him with me, so that, while I am in prison for the good news, he might attend to my wants on your behalf.
 \v 14 But I do not wish to do anything without your consent, because I want your generosity to be voluntary and not, as it were, compulsory.
-\v 15 It may be that he was separated from you for an hour, for this reason, so that you might have him back for ever,
+\v 15 It may be that he was separated from you for an hour, for this reason, so that you might have him back [us:forever|cth:for ever],
 \v 16 no longer as a slave, but as something better – a dearly loved [neut:friend and follower of the Lord|masc:brother], especially dear to me, and how much more so to you, not only as [neut:a person|masc:your fellow man], but as your fellow Christian!
 \v 17 If, then, you count me your friend, receive him as you would me.
 \v 18 If he has caused you any loss, or owes you anything, charge it to me.

--- a/source/58-Hebrews.usfm.db
+++ b/source/58-Hebrews.usfm.db
@@ -41,7 +41,7 @@
 \q2 And the flames of fire his servants’;
 \m
 \v 8 while of the Son he said –
-\q ‘God is your throne for ever and ever;
+\q ‘God is your throne [us:forever|cth:for ever] and ever;
 \q2 The [us:scepter|cth:sceptre] of his kingdom is the [us:scepter|cth:sceptre] of Justice;
 \q1
 \v 9 You love righteousness and hates iniquity;
@@ -252,7 +252,7 @@
 \v 22 And the oath shows the corresponding superiority of the covenant of which Jesus is appointed the surety.
 \v 23 Again, new Levitical priests are continually being appointed, because death prevents their remaining in office;
 \v 24 but Jesus remains for all time, and therefore the priesthood that he holds will never pass to another.
-\v 25 And that is why he is able to save perfectly those who come to God through him, living for ever, as he does, to intercede of their behalf.
+\v 25 And that is why he is able to save perfectly those who come to God through him, living [us:forever|cth:for ever], as he does, to intercede of their behalf.
 \p
 \v 26 This was the high priest that we needed – holy, innocent, spotless, withdrawn from sinners, exalted above the highest heaven,
 \v 27 one who has no need to offer sacrifices daily as those high priests have, first for their own sins, and then for those of the people. For this he did once and for all, when he offered himself as the sacrifice.
@@ -500,7 +500,7 @@
 \m
 \v 7 Do not forget your leaders, [neut:who|masc:the men who] told you God's message. Recall the close of their lives, and imitate their faith.
 \p
-\v 8 Jesus Christ is the same yesterday and today – yes, and for ever!
+\v 8 Jesus Christ is the same yesterday and today – yes, and [us:forever|cth:for ever]!
 \v 9 Do not let yourselves be carried away by the various novel forms of teaching. It is better to rely for spiritual strength on the divine help, than on regulations regarding food; for those whose lives are guided by such regulations have not found them of service.
 \v 10 We are not without an altar; but it is one at which those who still worship in the tent have no right to eat.
 \v 11 The bodies of those animals whose blood is brought by the high priest into the sanctuary, as an offering for sin, are burnt outside the camp.
@@ -517,7 +517,7 @@
 \v 19 And I the more earnestly ask for your prayers, so that I may be restored to you the sooner.
 \p
 \v 20 May God, the source of all peace, who brought back from the dead him who, ‘by virtue of the blood that rendered valid the unchangeable covenant, is the great shepherd of God's Sheep,’ Jesus, our Lord –
-\v 21 may God make you perfect in everything that is good, so that you may be able to do his will. May he bring out in us all that is pleasing in his sight, through Jesus Christ, to whom be all glory for ever and ever. Amen.
+\v 21 may God make you perfect in everything that is good, so that you may be able to do his will. May he bring out in us all that is pleasing in his sight, through Jesus Christ, to whom be all glory [us:forever|cth:for ever] and ever. Amen.
 \p
 \v 22 I beg you, [neut:friends|masc:brothers], to bear with these words of advice. For I have written only very briefly to you.
 \p

--- a/source/60-1 Peter.usfm.db
+++ b/source/60-1 Peter.usfm.db
@@ -57,7 +57,7 @@
 \q The grass fades,
 \q2 its flower falls,
 \q3
-\v 25 but the teaching of the Lord remains for ever.’
+\v 25 but the teaching of the Lord remains [us:forever|cth:for ever].’
 \m And that is the teaching of the good news which has been told to you.
 \c 2
 \v 1 Now that you have done with all malice, all deceitfulness, insincerity, jealous feelings, and all backbiting,
@@ -145,7 +145,7 @@
 \v 8 Above all things, let your love for one another be earnest, for ‘Love throws a veil over countless sins.’
 \v 9 Never grudge hospitality to one another.
 \v 10 Whatever the gift that each has received, use it in the service of others, as good stewards of the varied bounty of God.
-\v 11 When anyone speaks, [neut:they should|masc:he should] speak as one who is delivering the oracles of God. When anyone is [us:endeavoring|cth:endeavouring] to serve others, [neut:they should|masc:he should] do so in reliance on the strength which God supplies; so that in everything God may be [us:honored|cth:honoured] through Jesus Christ – to whom be ascribed all [us:honor|cth:honour] and might for ever and ever. Amen.
+\v 11 When anyone speaks, [neut:they should|masc:he should] speak as one who is delivering the oracles of God. When anyone is [us:endeavoring|cth:endeavouring] to serve others, [neut:they should|masc:he should] do so in reliance on the strength which God supplies; so that in everything God may be [us:honored|cth:honoured] through Jesus Christ – to whom be ascribed all [us:honor|cth:honour] and might [us:forever|cth:for ever] and ever. Amen.
 \rem Titleless Section Break
 \b
 \p
@@ -173,7 +173,7 @@
 \v 8 Exercise self-control, be watchful. Your adversary, the devil, like a roaring lion, is prowling about, eager to devour you.
 \v 9 Stand firm against him, strong in your faith; knowing, as you do, that the sufferings which you are undergoing are being endured to the full by [neut:the Lord's followers|masc:your brotherhood] throughout the world.
 \v 10 God, from whom all help comes, and who called you, by your union with Christ, into his eternal glory, will, when you have suffered for a little while, himself perfect, establish, strengthen you.
-\v 11 To him be ascribed dominion for ever. Amen.
+\v 11 To him be ascribed dominion [us:forever|cth:for ever]. Amen.
 \rem Titleless Section Break
 \b
 \p

--- a/source/61-2 Peter.usfm.db
+++ b/source/61-2 Peter.usfm.db
@@ -94,4 +94,4 @@
 \v 15 Regard our Lord's forbearance as your one hope of salvation. This is what our dear [neut:friend|masc:brother] Paul wrote to you, with the wisdom that God gave him.
 \v 16 It is the same in all his letters, when he speaks in them about these subjects. There are some things in them difficult to understand, which untaught and weak people distort, just as they do all other writings, to their own ruin.
 \v 17 You must, therefore, dear friends, now that you know this beforehand, be on your guard against being led away by the errors of reckless people, and so lapsing from your present steadfastness;
-\v 18 and advance in the love and knowledge of our Lord and [us:Savior|cth:Saviour], Jesus Christ. All glory be to him now and for ever.
+\v 18 and advance in the love and knowledge of our Lord and [us:Savior|cth:Saviour], Jesus Christ. All glory be to him now and [us:forever|cth:for ever].

--- a/source/62-1 John.usfm.db
+++ b/source/62-1 John.usfm.db
@@ -70,7 +70,7 @@
 \p
 \v 15 Do not love the world or what the world can offer. When anyone loves the world, there is no love for the Father in [neut:them|masc:him].
 \v 16 For all that the world can offer – the desires for physical pleasure, the enticements to the eye, the arrogance of wealth – belongs, not to the Father, but to the world.
-\v 17 And the world, and all that it gratifies, is passing away, but [neut:they who do|masc:he who does] God's will [neut:remain|masc:remains] for ever.
+\v 17 And the world, and all that it gratifies, is passing away, but [neut:they who do|masc:he who does] God's will [neut:remain|masc:remains] [us:forever|cth:for ever].
 \s Warnings against an antichrist
 \p
 \v 18 My children, it is the last hour. You were told that an antichrist was coming; and many antichrists have already arisen. This is why we know that this is the last hour.

--- a/source/65-Jude.usfm.db
+++ b/source/65-Jude.usfm.db
@@ -38,7 +38,7 @@
 \v 10 But these [neut:people|masc:men] malign whatever they do not understand; while they use such things as they know by instinct (like the animals that have no reason) for their own corruption.
 \v 11 Alas for them! They walk in the steps of Cain; led astray by Balaam's love of gain, they plunge into sin, and meet their ruin through rebellion like Korah.
 \v 12 These are the [neut:people|masc:men] who are blots on your ‘love-feasts,’ when they feast together and provide without scruple for themselves alone. They are clouds without rain, driven before the winds; they are leafless trees without a vestige of fruit, dead through and through, torn up by the roots;
-\v 13 they are wild sea waves, foaming with their own shame; they are ‘wandering stars,’ for which the blackest darkness has been reserved for ever.
+\v 13 they are wild sea waves, foaming with their own shame; they are ‘wandering stars,’ for which the blackest darkness has been reserved [us:forever|cth:for ever].
 \p
 \v 14 To these [neut:people|masc:men], as to others, Enoch, the seventh in descent from Adam, declared – ‘See! The Lord has come with his hosts of holy ones around him,
 \v 15 to execute judgment on all [neut:people|masc:men], and to convict all godless people of all their godless acts, which in their ungodliness they have committed, and of all the harsh words which they have spoken against him, godless sinners that they are!’

--- a/source/66-Revelation.usfm.db
+++ b/source/66-Revelation.usfm.db
@@ -26,7 +26,7 @@
 \p
 \v 4 From John, to the seven churches which are in Roman Asia. Blessing and peace be yours from him who is, and who was, and who will be, and from the seven spirits that are before his throne,
 \v 5 and from Jesus Christ, the faithful witness, the first-born from the dead, and the Ruler of all the kings of the earth. To him who loves us and freed us from our sins by his own blood –
-\v 6 and he made us a kingdom of priests in the service of God, his Father! – to Him be ascribed glory and dominion for ever. Amen.
+\v 6 and he made us a kingdom of priests in the service of God, his Father! – to Him be ascribed glory and dominion [us:forever|cth:for ever]. Amen.
 \v 7 He is coming among the clouds! Every eye will see him, even those who pierced him and all the nations of the earth will mourn over him. So will it be. Amen.
 \rem Titleless Section Break
 \b
@@ -42,7 +42,7 @@
 \v 15 and his feet were like brass as when molten in a furnace; his voice was like the sound of many streams,
 \v 16 in his right hand he held seven stars, from his mouth came a sharp two-edged sword, and his face was like the sun in the fulness of its power.
 \v 17 And, when I saw him, I fell at his feet like one dead. He laid his hand on me and said – \wj ‘Do not be afraid. I am the First and the Last,\wj*
-\v 18 \wj the Everliving. I died, and I am alive for ever and ever. And I hold the keys of death and of Hades.\wj*
+\v 18 \wj the Everliving. I died, and I am alive [us:forever|cth:for ever] and ever. And I hold the keys of death and of Hades.\wj*
 \v 19 \wj Therefore write of what you have seen and of what is happening now and of what is about to take place –\wj*
 \v 20 \wj the mystic meaning of the seven stars which you saw in my right hand, and the seven golden lamps. The seven stars are the angels of the seven churches, and the seven lamps are the seven churches.\wj*
 \c 2
@@ -138,8 +138,8 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \v 8 These four creatures have each of them six wings, and all [us:around|cth:round], and within, they are full of eyes; and day and night they never cease to say –
 \q ‘Holy, holy, holy is the Lord, our God, the Almighty, who was, and who is, and who will be.’
 \m
-\v 9 And, whenever these creatures give praise and [us:honor|cth:honour] and thanks to him who is seated on the throne, to him who lives for ever and ever,
-\v 10 the twenty-four elders prostrate themselves before him who is seated on the throne, and worship him who lives for ever and ever, and throw down their crowns before the throne, saying –
+\v 9 And, whenever these creatures give praise and [us:honor|cth:honour] and thanks to him who is seated on the throne, to him who lives [us:forever|cth:for ever] and ever,
+\v 10 the twenty-four elders prostrate themselves before him who is seated on the throne, and worship him who lives [us:forever|cth:for ever] and ever, and throw down their crowns before the throne, saying –
 \q
 \v 11 ‘Worthy are you, our Lord and God, to receive all praise, and [us:honor|cth:honour], and power, for you did create all things, and at your bidding they came into being and were created.’
 \m
@@ -162,7 +162,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \q ‘Worthy is the Lamb that was sacrificed to receive all power, and wealth, and wisdom, and might, and [us:honor|cth:honour], and praise, and blessing.’
 \m
 \v 13 And I heard every created thing in the air, and on the earth, and under the earth, and on the sea, and all that is in them crying –
-\q ‘To him who is seated on the throne and to the Lamb be ascribed all blessing, and [us:honor|cth:honour], and praise, and dominion for ever and ever.’
+\q ‘To him who is seated on the throne and to the Lamb be ascribed all blessing, and [us:honor|cth:honour], and praise, and dominion [us:forever|cth:for ever] and ever.’
 \m
 \v 14 And the four creatures said ‘Amen,’ and the elders prostrated themselves and worshiped.
 \c 6
@@ -220,7 +220,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \m
 \v 11 And all the angels were standing [us:around|cth:round] the throne and the elders and the four creatures, and they prostrated themselves on their faces in front of the throne and worshiped God,
 \v 12 saying –
-\q ‘Amen. Blessing and praise, and wisdom, and thanksgiving, and [us:honor|cth:honour], and power, and might be ascribed to our God for ever and ever. Amen.’
+\q ‘Amen. Blessing and praise, and wisdom, and thanksgiving, and [us:honor|cth:honour], and power, and might be ascribed to our God [us:forever|cth:for ever] and ever. Amen.’
 \m
 \rem Titleless Section Break
 \b
@@ -291,7 +291,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \v 3 and he cried in a loud voice like the roaring of a lion. At his cry the seven peals of thunder spoke, each with its own voice.
 \v 4 And, when they spoke, I was about to write; but I heard a voice from heaven say – ‘Keep secret what the seven peals of thunder said, and do not write it down.’
 \v 5 Then the angel, whom I had seen standing on the sea and on the land, raised his right hand to the heavens,
-\v 6 and swore by him who lives for ever and ever, who created the heavens and all that is in them, and the earth and all that is in it, and the sea and all that is in it, that time should cease to be.
+\v 6 and swore by him who lives [us:forever|cth:for ever] and ever, who created the heavens and all that is in them, and the earth and all that is in it, and the sea and all that is in it, that time should cease to be.
 \v 7 Moreover at the time when the seventh angel will speak, when he is ready to blow his blast, then the hidden purposes of God, of which he told the good news to his servants, the prophets, are at once fulfilled.
 \v 8 Then came the voice which I had heard from heaven. It spoke to me again, and said – ‘Go and take the book that is open in the hand of the angel who stands on the sea and on the land.’
 \v 9 So I went to the angel and asked him to give me the little book. And he said ‘Take it, and eat it. It will be bitter to your stomach, but in your mouth it will be as sweet as honey.’
@@ -318,7 +318,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \b
 \p
 \v 15 Then the seventh angel blew; and loud voices were heard in heaven saying –
-\q ‘The kingdom of the world has become the kingdom of our Lord and of his Christ, and he will reign for ever and ever.’
+\q ‘The kingdom of the world has become the kingdom of our Lord and of his Christ, and he will reign [us:forever|cth:for ever] and ever.’
 \m
 \v 16 At this the twenty-four elders, who were seated on their thrones before God, prostrated themselves on their faces and worshiped Him,
 \v 17 saying –
@@ -390,7 +390,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \p
 \v 9 Then a third angel followed them, crying in a loud voice – ‘Whoever worships the Beast and its image, and receives its brand on his forehead or on his hand,
 \v 10 that [neut:person will drink the maddening wine of God that has been poured unmixed into the cup of his wrath, and they|masc:man will drink the maddening wine of God that has been poured unmixed into the cup of his wrath, and he] will be tortured with fire and [us:sulfur|cth:sulphur] before the eyes of the holy angels and before the eyes of the Lamb.
-\v 11 The smoke from their torture rises for ever and ever, and they have no rest day nor night – those who worship the Beast and its image, and all who are branded with its name.’
+\v 11 The smoke from their torture rises [us:forever|cth:for ever] and ever, and they have no rest day nor night – those who worship the Beast and its image, and all who are branded with its name.’
 \v 12 (Here there is need for endurance on the part of Christ's people – those who lay to heart the commands of God and the faith of Jesus.)
 \v 13 Then I heard a voice from heaven saying ‘Write: “Blessed are the dead who from this hour die in union with the Lord.”’
 \p “Yes,” answers the Spirit, “that they may rest from their toil. Their good deeds go with them.”
@@ -419,7 +419,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \m
 \v 5 After this I saw that the inmost shrine of the tent of testimony in heaven was opened,
 \v 6 and out of it came the seven angels with the seven curses. They were adorned with precious stones, pure and bright, and had golden girdles [us:around|cth:round] their breasts.
-\v 7 One of the four creatures gave the seven angels seven golden bowls, filled with the wrath of God who lives for ever and ever.
+\v 7 One of the four creatures gave the seven angels seven golden bowls, filled with the wrath of God who lives [us:forever|cth:for ever] and ever.
 \v 8 The Temple was filled with smoke from the glory and majesty of God; and no one could enter the Temple, until the seven curses inflicted by the seven angels were at an end.
 \c 16
 \v 1 Then I heard a loud voice, which came from the Temple, saying to the seven angels – ‘Go and empty the seven bowls of the wrath of God on the earth.’
@@ -505,7 +505,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \q ‘Hallelujah! To our God belong salvation, and glory, and Power,
 \v 2 for true and righteous are his judgments. For he has passed judgment on the Great Harlot who was corrupting the earth by her licentiousness, and he has taken vengeance on her for the blood of his servants.’
 \m
-\v 3 Again they cried – ‘Hallelujah!’ And the smoke from her ruins rises for ever and ever.
+\v 3 Again they cried – ‘Hallelujah!’ And the smoke from her ruins rises [us:forever|cth:for ever] and ever.
 \v 4 Then the twenty-four elders and the Four creatures prostrated themselves and worshiped God who was seated on the throne, crying – ‘Amen, Hallelujah!’;
 \v 5 and from the throne there came a voice which said –
 \q ‘Praise our God all you who serve him, You who worship him, both high and low.’
@@ -546,7 +546,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \v 7 When the thousand years are ended, Satan will be let loose from his prison,
 \v 8 and he will come out to deceive the nations that live in the four corners of the earth – Gog and Magog. He will come to gather them together for battle; and their number will be as great as the sand on the sea-shore.
 \v 9 They went up over the breadth of the whole earth, and surrounded the camp of Christ's people and the city that he loves. Then fire fell from the heavens and consumed them;
-\v 10 and the devil, their deceiver, was hurled into the lake of fire and [us:sulfur|cth:sulphur], where the Beast and the false prophet already were, and they will be tortured day and night for ever and ever.
+\v 10 and the devil, their deceiver, was hurled into the lake of fire and [us:sulfur|cth:sulphur], where the Beast and the false prophet already were, and they will be tortured day and night [us:forever|cth:for ever] and ever.
 \rem Titleless Section Break
 \b
 \p
@@ -593,7 +593,7 @@ These are the words of him who holds the seven stars in his right hand, and walk
 \v 2 in the middle of the street of the city. On each side of the river was a Tree of life which bore twelve kinds of fruit, yielding its fruit each month; and the leaves of the tree were for the healing of the nations.
 \v 3 Every thing that is accursed will cease to be. The throne of God and of the Lamb will be within it, and his servants will worship him;
 \v 4 they will see his face, and his name will be on their foreheads.
-\v 5 Night will cease to be. They have no need of the light of a lamp, nor have they the light of the sun; for the Lord God will be their light, and they will reign for ever and ever.
+\v 5 Night will cease to be. They have no need of the light of a lamp, nor have they the light of the sun; for the Lord God will be their light, and they will reign [us:forever|cth:for ever] and ever.
 \s Conclusion
 \p
 \v 6 Then the angel said to me – “These words may be trusted and are true. The Lord, the God that inspires the prophets, sent his angel to show his servants what must quickly take place;


### PR DESCRIPTION
See commit message for more details.

This was achieved by find-and-replace, but I looked over all the changes to make sure nothing unexpected got changed.
