### PR TITLE
Gal. 1:18 - Correct "fortnight" to "fifteen days"

### DIFF
--- a/source/48-Galatians.usfm.db
+++ b/source/48-Galatians.usfm.db
@@ -48,7 +48,7 @@
 \v 15 But when God, who had set me apart even before my birth, and who called me by his love,
 \v 16 saw fit to reveal his Son in me, so that I might tell the good news of him among the Gentiles, then at once, instead of consulting any human being,
 \v 17 or even going up to Jerusalem to see those who were apostles before me, I went to Arabia, and came back again to Damascus.
-\v 18 Three years [us:afterward|cth:afterwards] I went up to Jerusalem to make the acquaintance of Peter, and I stayed a fortnight with him.
+\v 18 Three years [us:afterward|cth:afterwards] I went up to Jerusalem to make the acquaintance of Peter, and I stayed with him fifteen days.
 \v 19 I did not, however, see any other apostle, except James, the Master's brother.
 \v 20 (As to what I am now writing to you, I call God to witness that I am speaking the truth).
 \v 21 [us:Afterward|cth:Afterwards] I went to the districts of Syria and Cilicia.


### PR DESCRIPTION
In the Greek (see [here](https://archive.org/stream/newtestamentino01westgoog#page/n473/mode/2up)) the word being translated is δεκαπέντε.
Transliterated into English, it becomes dekapente.
At this point it can be recognized as "deca", meaning ten and "penta", meaning five.
Because a fortnight is only fourteen days, it is an imprecise translation.