### PR TITLE
Issue 318 "Faith of" should be changed to "name of"

### DIFF
--- a/source/40-Matthew.usfm.db
+++ b/source/40-Matthew.usfm.db
@@ -1396,5 +1396,5 @@
 \v 16 The eleven disciples went to Galilee, to the mountain where Jesus told them to meet him;
 \v 17 and, when they saw him, they bowed to the ground before him; although some felt doubtful.
 \v 18 Then Jesus came up, and spoke to them, saying, \wj “All authority in heaven and on the earth has been given to me.\wj*
-\v 19 \wj Therefore go and make disciples of all the nations, baptizing them into the faith of the Father, the Son, and the Holy Spirit,\wj*
+\v 19 \wj Therefore go and make disciples of all the nations, baptizing them into the name of the Father, the Son, and the Holy Spirit,\wj*
 \v 20 \wj and teaching them to lay to heart all the commands that I have given you; and, remember, I myself am with you every day until the close of the age.”\wj*

--- a/source/44-Acts.usfm.db
+++ b/source/44-Acts.usfm.db
@@ -141,7 +141,7 @@
 \p
 \v 37 When the people heard this, they were conscience-smitten, and said to Peter and the rest of the apostles, “[neut:Friends|masc:Brothers], what can we do?”
 \p
-\v 38 “Repent,” answered Peter, “and be baptized every one of you in the faith of Jesus Christ for the forgiveness of your sins; and then you will receive the gift of the Holy Spirit.
+\v 38 “Repent,” answered Peter, “and be baptized every one of you in the name of Jesus Christ for the forgiveness of your sins; and then you will receive the gift of the Holy Spirit.
 \v 39 For the promise is for you and for your children, and also for all those now far away, who may be called by the Lord our God.”
 \p
 \v 40 Peter spoke to them for a long time using many other arguments and pleaded with them – “Save yourselves from the perverse spirit of this age.”
@@ -438,7 +438,7 @@ On that very day a great persecution broke out against the church which was in J
 \p
 \v 14 When the apostles at Jerusalem heard that the Samaritans had welcomed God's message, they sent Peter and John to them;
 \v 15 and they, on their arrival, prayed that the Samaritans might receive the Holy Spirit.
-\v 16 (As yet the Spirit had not descended on any of them; they had only been baptized into the faith of the Lord Jesus).
+\v 16 (As yet the Spirit had not descended on any of them; they had only been baptized into the name of the Lord Jesus).
 \v 17 Then Peter and John placed their hands on them, and they received the Holy Spirit.
 \p
 \v 18 When Simon saw that it was through the placing of the apostles' hands on them that the Spirit was given, he brought them a sum of money and said,
@@ -616,7 +616,7 @@ She opened her eyes, and, seeing Peter, sat up.
 \v 45 Those converts from Judaism, who had come with Peter, were amazed that the gift of the Holy Spirit had been bestowed even on the Gentiles;
 \v 46 for they heard them speaking in different languages and extolling God. At this Peter asked,
 \v 47 “Can anyone refuse the water for the baptism of these people, now that they have received the Holy Spirit as we did ourselves?”
-\v 48 And he directed that they should be baptized in the faith of Jesus Christ; after which they asked him to stay there a few days longer.
+\v 48 And he directed that they should be baptized in the name of Jesus Christ; after which they asked him to stay there a few days longer.
 \c 11
 \rem Titleless Section Break
 \b
@@ -1037,7 +1037,7 @@ In that city we spent several days.
 \v 3 “What then was your baptism?” Paul asked.
 \v 4 “John's baptism was a baptism on repentance,” rejoined Paul, “and John told the people (speaking of the ‘one coming’ after him) that they should believe in him – that is in Jesus.”
 \p
-\v 5 On hearing this, they were baptized into the faith of the Lord Jesus,
+\v 5 On hearing this, they were baptized into the name of the Lord Jesus,
 \v 6 and, after Paul had placed his hands on them, the Holy Spirit descended on them, and they began to speak in other languages and to preach.
 \v 7 There were about twelve of them in all.
 \p

--- a/source/46-1 Corinthians.usfm.db
+++ b/source/46-1 Corinthians.usfm.db
@@ -40,9 +40,9 @@
 \v 10 But I appeal to you, [neut:my friends|masc:brothers], by the name of our Lord Jesus Christ, to agree in what you profess, and not to allow divisions to exist among you, but to be united – of one mind and of one opinion.
 \v 11 For I have been informed, my [neut:friends|masc:brothers], by the members of Chloe's household, that party feeling exists among you.
 \v 12 I mean this: that every one of you says either ‘I follow Paul,’ or ‘I Apollos,’ or ‘I Cephas,’ or ‘I Christ.’
-\v 13 You have torn the Christ in pieces! Was it Paul who was crucified for you? Or were you baptized into the faith of Paul?
+\v 13 You have torn the Christ in pieces! Was it Paul who was crucified for you? Or were you baptized into the name of Paul?
 \v 14 I am thankful that I did not baptize any of you except Crispus and Gaius,
-\v 15 so that no one can say that you were baptized into my faith.
+\v 15 so that no one can say that you were baptized into my name.
 \v 16 I baptized also the household of Stephanas. I do not know that I baptized anyone else.
 \v 17 My mission from Christ was not to baptize, but to tell the good news; not, however, in the language of philosophy, in case the cross of the Christ should be robbed of its meaning.
 \rem Titleless Section Break


### PR DESCRIPTION
"Faith of" should be changed to "name of" in Matthew 28:19, Acts 2:38, 8:16, 10:48, 19:5, 1 Corinthians 1:13, 1:15 consistent with the same Greek word, onoma, in Acts 3:6, 4:10, 4:18, 4:30, 5:40, 8:12, 9:27, 15:26, 16:18, 19:13, 19:17, 21:13, 22:16, 26:9, 1 Corinthians 1:2, 1:10, 5:4, 6:11, Ephesians 5:20, Philippians 2:10, Colossians 3:17, 2 Thessalonians 1:12, 3:6