### PR TITLE
Jeremiah: fix a lot of typos, prevent words breaking over lines

### DIFF
--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -9,7 +9,8 @@
 
 \c 1
 
-\p v 1 The messages of Jeremiah, the son of Hilkiah, a
+\p
+\v 1 The messages of Jeremiah, the son of Hilkiah, a
 member of the priestly order resident in Anathoth in
 the district of Benjamin.
 
@@ -74,7 +75,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q
 \v 15 For I, saith Jehovah, do summon
 \q2 The northern kingdoms all;
-\q Each king shall come and set hi throne
+\q Each king shall come and set his throne
 \q2 At the gates that lead into Jerusalem,
 \q And against her encircling walls,
 \q2 And against all the cities of Judah.
@@ -141,15 +142,15 @@ Voice). "A boiling pot," I answered, "facing the
 \q What wrong did your fathers discover in Me,
 \q2 That they went from Me afar,
 \q To follow after vanities,
-\q2 Till they, too, becane a vanity,
+\q2 Till they, too, became a vanity,
 \q
-\v 6 And never sought afer Jehovah,
+\v 6 And never sought after Jehovah,
 \q2 Who brought them up out of Egypt,
 \q And led them through the desert,
 \q2 A land of steppes and pits,
 \q A land of drought and gloom,
 \q2 A land that no man traversed,
-\q2 A lanf where no man dwelt?
+\q2 A land where no man dwelt?
 \q
 \v 7 And I brought you into a garden-land,
 \q2 To enjoy its fruits and its good things:
@@ -157,7 +158,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q2 And made Mine inheritance loathsome,
 \q
 \v 8 No priest was heard any more
-\q2 Enquiring afer Jehovah;
+\q2 Enquiring after Jehovah;
 \q They that handle the law did not know Me,
 \q2 The rulers rebelled against Me.
 \q The prophets spoke by Baal,
@@ -247,7 +248,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q
 \v 24 A heifer run wild in the desert,
 \q2 Aglow with the heat of ther passion;
-\q That snifeth the wind in her longing,
+\q That sniffeth the wind in her longing,
 \q2 And who can turn her back?
 \q No one need wearily seek her–
 \q2 In her month she is sure to be found.
@@ -255,7 +256,7 @@ Voice). "A boiling pot," I answered, "facing the
 \v 25 Run not the shoes off thy feet,
 \q2 And spare thy throat, lest it parch.
 \q But thou saidst,"There is no hope – none:
-\q2 For I am inlove with strangers,
+\q2 For I am in love with strangers,
 \q2 And after them will I go."
 
 
@@ -317,7 +318,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q2 Because thou dost claim to be sinless.
 \q
 \v 36 Why runnest thou hither and thither
-\q2 Witg so frivolous a heart?
+\q2 With so frivolous a heart?
 \q Thou shalt yet reap shame from Egypt,
 \q2 As thou has reaped shame from Assyria.
 \q
@@ -351,7 +352,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q2 And by thy wicked ways,
 \q
 \v 3 And through thy many lovers
-\q2 Thou hast let thysef be snared.
+\q2 Thou hast let thyself be snared.
 \q Thou hast a harlot's forhead,
 \q2 Refusing to be abashed,
 \q
@@ -370,12 +371,12 @@ Voice). "A boiling pot," I answered, "facing the
 
 \p
 \v 6 In the days of the King Josiah Jehovah said to me:
-"Hast thou seem what back-sliding Israel did? She
+"Hast thou seem what backsliding Israel did? She
 went up on every high mountain and under every
 \v 7 green tree and ther she played the harlot. I had
 hoped that, after all this, she would return to Me. But
 no! she did not return. Her faithless sister Judah
-\v 8 saw that I had put back-sliding Israel away because of
+\v 8 saw that I had put backsliding Israel away because of
 her adultery, and that I had given her a bill of divorce;
 nevertheless faithless Judah was not at all afraid, but
 \v 9 she too went and played the harlot, defiling the land
@@ -407,7 +408,7 @@ O backsliding Israel, turn,
 \v 14 Return, ye backsliding children, saith Jehovah,
 for I am your husband and lord; and I will take
 one of you from each city and two from each clan,
-\v 15 and I will brring you to Zion, and give you rulers after
+\v 15 and I will bring you to Zion, and give you rulers after
 My own mind, who shall tend you with wisdom and
 \v 16 skill. And when in those days you have grown
 numerous and fruitful in the land, saith Jehovah, men
@@ -446,7 +447,7 @@ your forefathers for an inheritance.
 \q "Behold, we are come unto Thee,
 \q2 For Thou art Jehovah our God.
 \q
-\v 23 The hills are but a dellusion,
+\v 23 The hills are but a delusion,
 \q2 And the orgies upon the mountains;
 \q In Jehovah our God alone
 \q2 Is Israel's salvation.
@@ -471,7 +472,7 @@ your forefathers for an inheritance.
 \v 1 "O Israel, if thou wilt return," saith Jehovah,
 \q2 If thou but return unto Me,
 \q And put out of My sight those things that I loathe;
-\q2 If thou raom not hither and thither;
+\q2 If thou roam not hither and thither;
 \q
 \v 2 If sincerely and justly and truly
 \q2 Thou swear, 'As Jehovah liveth,'
@@ -532,7 +533,7 @@ your forefathers for an inheritance.
 \q2 To Jerusalem and this people:
 \q A glowing wind from the desert
 \q2 Cometh straight upon My people,
-\q But not tp winnow or cleanse–
+\q But not to winnow or cleanse–
 \q
 \v 12 Too keen is the blast for that.
 \q2 So now I will utter My judgment upon them.
@@ -550,7 +551,7 @@ your forefathers for an inheritance.
 \v 15 Hark! a message from Dan,
 \q2 From Mount Ephraim, evil tidings;
 \q
-\v 16 Procalaim it among the nations,
+\v 16 Proclaim it among the nations,
 \q2 And publish it over Jerusalem.
 \q Behold! leopards are coming
 \q2 From a land that is far away,
@@ -575,7 +576,7 @@ your forefathers for an inheritance.
 \q
 \v 19 O the pain, the pain in my bosom,
 \q2 The walls of my heart are athrob:
-\q My heart is a tumuly within me,
+\q My heart is a tumult within me,
 \q2 I cannot hold my peace;
 \q For the sound of the trumpet I hear,
 \q2 The din and alarum of battle.
@@ -640,7 +641,7 @@ your forefathers for an inheritance.
 \q Hark! 'tis the daughter of Zion
 \q2 That gaspeth and spreadeth her hands,
 \q Saying, "Ah! woe is me! I am faint,
-\q2 I am sinking – the victim of muderers."
+\q2 I am sinking – the victim of murderers."
 
 
 
@@ -648,7 +649,7 @@ your forefathers for an inheritance.
 
 \c 5
 \q
-\v 1 Run to tand fro through the streets of Jerusalem,
+\v 1 Run to and fro through the streets of Jerusalem,
 \q2 Look ye around and examine;
 \q Search in her open spaces
 \q2 If ye can find a man–
@@ -681,7 +682,7 @@ your forefathers for an inheritance.
 \q
 \v 6 Soon therefore shall they be slain
 \q2 By a lion out of the forest;
-\q2 A wolf from the steppes shal despoil them.
+\q2 A wolf from the steppes shall despoil them.
 \q A leopard shall lurk by their cities,
 \q2 And rend all that issue therefrom.
 \q For many are their their transgressions,
@@ -708,7 +709,7 @@ your forefathers for an inheritance.
 \v 10 Get ye up to her vines and destroy them,
 \q2 Make an utter end of them;
 \q Take away her branches,
-\q2 For they are not Jehova's.
+\q2 For they are not Jehovah's.
 \q
 \v 11 For utterly faithless to Me
 \q2 Are the households of Israel and Judah;
@@ -783,7 +784,7 @@ your forefathers for an inheritance.
 \q2 "Let us fear Jehovah, our God,
 \q Who giveth the rain in its season,
 \q2 The early and latter rain,
-\q And into us reseveth
+\q And into us reserveth
 \q2 the weeks appointed for harvest."
 \q
 \v 25 This order your sins have disturbed,
@@ -809,7 +810,7 @@ your forefathers for an inheritance.
 \v 30 An appailing, a horrible thing
 \q2 Is come to pass in the land.
 \q
-\v 31 The prophets prphesy falsely,
+\v 31 The prophets prophesy falsely,
 \q2 And from them do the priests take their teaching,
 \q And My people love it so;
 \q2 But what will ye do in the end?
@@ -857,7 +858,7 @@ your forefathers for an inheritance.
 \v 8 O Jerusalem, be admonished,
 \q2 Lest My soul from thee be severed,
 \q Lest I make thee a desolation,
-\q2 An unihabited land.
+\q2 An uninhabited land.
 \q
 \v 9 Thus saith Jehovah of Hosts;
 \q "Glean like a vine full thoroughly
@@ -930,7 +931,7 @@ your forefathers for an inheritance.
 \v 20 Of what avail to Me
 \q2 Is the incense that cometh from Sheba,
 \q2 And sweet cane from a distant land?
-\q I accept not yout burnt-offerings,
+\q I accept not your burnt-offerings,
 \q2 Your sacrifice pleaseth Me not.
 \q
 \v 21 Therefore, thus saith Jehovah: Behold,
@@ -979,7 +980,7 @@ your forefathers for an inheritance.
 \q
 \v 28 Refractory are the all,
 \q2 They slander as they go;
-\q They are all of them brass amd iron,
+\q They are all of them brass and iron,
 \q2 They are all of them corrupt.
 \q
 \v 29 Fiercely the bellows blow,
@@ -1009,14 +1010,14 @@ this message from Jehovah, all ye men of Judah that
 \v 3 enter these gates to worship Jehovah. Thus saith
 Jehovah of Hosts, the God of Israel, Amend your ways
 and your doings, and I will guarantee this place as your
-\v 4 permanent home. But put no trust in lying messen-
-gers, who say: "This is the Temple of Jehovah, the
+\v 4 permanent home. But put no trust in lying
+messengers, who say: "This is the Temple of Jehovah, the
 \v 5 Temple of Jehovah, the Temple of Jehovah." For if
 you really amend your ways and your doings: if
 you really do justice as between man and man;
 \v 6 if you abstain from the oppression of the resident
-alien, the fatherless and the widow, from the shed-
-ding of innocent blood in this place, and from devotion
+alien, the fatherless and the widow, from the shedding
+of innocent blood in this place, and from devotion
 \v 7 to other gods to your own hurt, then I will guarantee
 you a home here for all time in the land that I gave
 your forefathers.
@@ -1048,8 +1049,8 @@ as I have hurled your brethren, the whole race of
 Ephraim.
 \p
 \v 16 As for thyself, offer no prayer for this people, raise
-no cry or prayer on their behalf, and make no inter-
-\v 17 cession to Me, for I will not listen to thee. Seest thou
+no cry or prayer on their behalf, and make no intercession
+\v 17 to Me, for I will not listen to thee. Seest thou
 not what they are doing in the cities of Judah and in
 \v 18 the streets of Jerusalem? The children gather wood,
 the fathers kindle the fire, and the women knead dough,
@@ -1103,8 +1104,8 @@ them, though they will not listen to thee, nor respond
 \p
 \v 30 The people of Judah, saith Jehovah, have done the
 thing I abhor: the very House that bears My name
-they have defiled by introducing into it their abomin-
-\v 31 able worship. They have built a sanctuary of Topheth
+they have defiled by introducing into it their abominable
+\v 31 worship. They have built a sanctuary of Topheth
 in the Valley of the son of Hinnom, for the burning of
 their sons and daughters in the fire, though this was
 no commandment of Mine – such a thing never entered
@@ -1129,12 +1130,12 @@ bridegroom and bride; for the land shall become a waste.
 \p
 \v 1 At the time, saith Jehovah, they shall bring out of
 their graves the bones of the kings, the princes, the
-priests, and the prophets, of Judah, and of the in-
-\v 2 habitants of Jerusalem, and they shall spread them
+priests, and the prophets, of Judah, and of the inhabitants
+\v 2 of Jerusalem, and they shall spread them
 before the sun and the moon and all the host of heaven,
 whom they loved and served and followed and sought
 and worshipped; and they shall remain ungathered
-and unburried, they shall be for dung on the face of the
+and unburied, they shall be for dung on the face of the
 \v 3 ground. And in all places to which I have driven them,
 every man that is left of this evil family would choose
 rather death than life, saith Jehovah of Hosts.
@@ -1168,7 +1169,7 @@ rather death than life, saith Jehovah of Hosts.
 \q
 \v 8 How can ye say, "We are wise,
 \q2 And with us is the law of Jehovah"?
-\q For see! the false pen of the sribes
+\q For see! the false pen of the scribes
 \q2 Hath turned it into a falsehood.
 \q
 \v 9 So the wise shall be put to shame,
@@ -1312,7 +1313,7 @@ rather death than life, saith Jehovah of Hosts.
 \q
 \v 11 I will make of Jerusalem ruins,
 \q2 A place for jackals to haunt;
-\q I will make of the cities of judah
+\q I will make of the cities of Judah
 \q2 An uninhabited waste.
 \q
 \v 12 Where is the man that Jehovah
@@ -1342,7 +1343,7 @@ rather death than life, saith Jehovah of Hosts.
 \v 17 Thus saith Jehovah of Hosts:
 \q Now mark ye well and summon
 \q2 The women that chant in dirges;
-\q And send for the skillful women,
+\q And send for the skilful women,
 \q2 That they may come in haste,
 \q2
 \v 18 And lift up for us a lament;
@@ -1551,8 +1552,8 @@ forefathers on the day that I brought them out of that
 iron furnace, the land of Egypt. I promised them then
 that, if they obeyed My voice, and conformed to all
 My commandments, they should be My people and I
-\v 5 would be their God, and thus the oath would be estab-
-lished that swore to their forefathers – to give them
+\v 5 would be their God, and thus the oath would be
+established that swore to their forefathers – to give them
 a land flowing with milk and honey, as it is this day."
 Then I answered and said, "Amen, Jehovah."
 \p
@@ -1604,8 +1605,8 @@ when they call to Me in the day of their calamity.
 \q2 He hath set it ablaze with lightning,
 \q2 And the branches thereof are marred.
 \p
-\v 17 For Jehovah of Hosts that planted thee hath pro-
-nounced evil against thee in requital for th evil in which
+\v 17 For Jehovah of Hosts that planted thee hath pronounced
+evil against thee in requital for the evil in which
 the households of Israel and Judah have vexatiously
 indulged, by burning sacrifice to the Baal."
 
@@ -1650,7 +1651,7 @@ indulged, by burning sacrifice to the Baal."
 
 
 
-\s Jeremiah's Persplexity and Prayer for Vengeance
+\s Jeremiah's Perplexity and Prayer for Vengeance
 
 
 \c 12
@@ -1805,7 +1806,7 @@ Jehovah the God of Israel, "Every jar must be filled with
 wine." And if they say to thee, "Why, of course we
 \v 13 know that every jar must be filled with wine," then this
 is what thou shalt say to them: Thus saith Jehovah:
-Soon-mark it well-I will fill with drunkenness all
+Soon – mark it well – I will fill with drunkenness all
 the inhabitants of this land – the kings that sit upon
 the throne of David, the priests, the prophets, and all
 \v 14 the inhabitants of Jerusalem; and I will dash them,
@@ -1986,9 +1987,9 @@ preaching lies in My name. I never sent them; they
 have no commission from Me; not a word have I
 spoken to them. What thy preach to you is nothing
 but a tissue of lying visions and idle divinations and
-\v 15 inventions of their own deceitful hearts. This there-
-fore is the message of Jehovah concerning those
-prophets who, without any commision from Me, are
+\v 15 inventions of their own deceitful hearts. This
+therefore is the message of Jehovah concerning those
+prophets who, without any commission from Me, are
 ceaselessly preaching that this land will never suffer
 from sword or famine: by sword and famine shall
 \v 16 those very prophets themselves be consumed, and the
@@ -2015,7 +2016,7 @@ them.
 \q And if into the city I go,
 \q2 Lo, there lie the victims of famine:
 \q Yea, prophet and priest alike,
-\q2 All wiltless, lie crouched on the ground,
+\q2 All witless, lie crouched on the ground,
 \q
 \v 19 Hast Thou utterly cast away Judah?
 \q2 Is Zion grown loathsome to Thee?
@@ -2200,7 +2201,7 @@ them.
 \q2 I have taken away My peace.
 \q
 \v 6 Both great and small in this land shall die,
-\q2 They shall be unburried, unmourned;
+\q2 They shall be unburied, unmourned;
 \q Not a man shall gash his body,
 \q2 Or shear his hair for them.
 \q
@@ -2273,7 +2274,7 @@ other gods; for no favour shall ye have from Me."
 \v 20 Shall a man make gods for himself,
 \q2 Which yet are no gods at all?
 \q
-\v 21 See then! I wil give them to feel–
+\v 21 See then! I will give them to feel–
 \q2 This once I will give them to feel–
 \q The weight of My mighty hand:
 \q2 And then shall they know that My name is Jehovah.
@@ -2327,13 +2328,13 @@ other gods; for no favour shall ye have from Me."
 \q And is never afraid for the coming of heat,
 \q2 But its leaves are for ever green–
 \q In the year of drought untroubled–
-\q2 And it yeildeth fruit without ceasing.
+\q2 And it yieldeth fruit without ceasing.
 
 
 \ms2 The Prophet's Prayer
 \q
 \v 9 "The heart is most treacherous of all things,
-\q2 And sick beyond cure: who cah know it?"
+\q2 And sick beyond cure: who can know it?"
 \q
 \v 10 "I, Jehovah, am Searcher of hearts,
 \q2 And Tester of thoughts am I,
@@ -2353,7 +2354,7 @@ other gods; for no favour shall ye have from Me."
 \v 13 O Jehovah, Thou Hope of Israel,
 \q2 Put to shame shall all be that forsake Thee;
 \q Yea, they that prove faithless to Thee
-\q2 In the land shall be put to confussion;
+\q2 In the land shall be put to confusion;
 \q Because they have forsaken
 \q2 The Fountain of Living Water.
 \q
@@ -2412,8 +2413,8 @@ this city riding on chariots and horses, accompanied
 by their princes, the men of Judah, and the citizens of
 Jerusalem; and the city shall be inhabited for ever.
 \v 26 From the cities of Judah, the neighbourhood of
-Jerusalem, and the district of Benjamin, from the low-
-land, the hill country, and the south, men shall come
+Jerusalem, and the district of Benjamin, from the lowland,
+the hill country, and the south, men shall come
 to the Temple with burnt-offerings and sacrifices,
 \v 27 oblations and frankincense, and praise-offerings. If,
 however, you refuse to give heed to Me and to keep the
@@ -2433,9 +2434,10 @@ shall devour the palaces of Jerusalem.
 \p
 \v 1 Jeremiah received from Jehovah the message which
 \v 2 follows: "Rise and go down to the potter's house–
-I have somewhat to say to thee, which I will com-
-\v 3 municate to thee there." So I went down to the
-potter's house: and there he was-engaged on a
+I have somewhat to say to thee, which I will
+communicate to thee there."
+\v 3 So I went down to the
+potter's house: and there he was – engaged on a
 \v 4 piece of work at the wheel. Now, if the thing he was
 making was spoiled in his hands, he would just shape
 the material over again into another such vessel as he
@@ -2462,7 +2464,7 @@ am fashioning plans for your discomfiture. Turn, then,
 every man of you, from your evil ways, and amend your
 \v 12 life and behaviour." But they will say, "No, there
 is no hope of that: rather will we follow devices of our
-own and yeild, every man of us, to the impulses of our
+own and yield, every man of us, to the impulses of our
 wicked and stubborn hearts."
 \v 13 Thus therefore saith Jehovah:
 \q Ask any heathen man
@@ -2558,8 +2560,8 @@ Jerusalem, to what Jehovah is about to say: Thus
 saith Jehovah of Hosts, the God of Israel: Mark
 this well. I will soon bring such a catastrophe upon
 this place as will make the ears of all who hear of it
-\v 4 tingle; because they have forsaken Me and de-
-nationalised this place by their burnt-offerings to other
+\v 4 tingle; because they have forsaken Me and
+denationalised this place by their burnt-offerings to other
 gods, strange alike to them and their forefathers;
 and the kings of Judah have filled this place with the
 \v 5 blood of innocent men. They have built Baal
@@ -2746,8 +2748,8 @@ are besieging you; but soon I will drive you with the
 will fight against you with outstretched hand and
 mighty arm – in anger, in fury, and in towering wrath.
 \v 6 Yes, I will smite the inhabitants of this city, both man
-\v 7 and beast, with a great and deadly pestilence. There-
-after, saith Jehovah, Zedekiah, king of Judah and his
+\v 7 and beast, with a great and deadly pestilence.
+Thereafter, saith Jehovah, Zedekiah, king of Judah and his
 ministers and the people in this city that survive the
 pestilence, sword and famine, I will deliver into the
 hands of Nebuchadrezzar, king of Babylon, and into
@@ -2824,7 +2826,7 @@ king of Judah:
 Though thou art to Me as Gilead,
 \q2 Or the (thick-wooded) summit of Lebanon,
 \q I will turn thee into a desert,
-\q2 An unihabited city.
+\q2 An uninhabited city.
 \q
 \v 7 I will dedicate men to destroy thee,
 \q2 Every one with his weapons;
@@ -2834,7 +2836,7 @@ Though thou art to Me as Gilead,
 \v 8 The people of many nations, as they pass by this city,
 shall ask one another why Jehovah has dealt thus with
 \v 9 this great city, and they shall answer: It is because
-they abandoned their convenant with Jehovah their
+they abandoned their covenant with Jehovah their
 God and gave themselves up to the worship and service
 of other gods.
 
@@ -2880,8 +2882,8 @@ this land he shall see no more."
 \q The shedding of innocent blood,
 \q2 And the practice of wrong and oppression.
 \q
-\v 18 This, therefore, is the message of Jehovah to Jehoia-
-\q kim, the son Josiah, king of Judah:
+\v 18 This, therefore, is the message of Jehovah to
+\q Jehoiakim, the son of Josiah, king of Judah:
 \q2 Woe unto this man Jehoiakim!
 \q No one for him shall lament
 \q2 " O brother of mine," "O sister."
@@ -2916,10 +2918,10 @@ this land he shall see no more."
 \q2 Thy pain as of woman in travail!
 \p
 \v 24 As truly as I live, saith Jehovah, though Coniah,
-the son of Jehoiakim, king of Judah, were the signet-
-ring on thy right hand, yet I would tear him off
+the son of Jehoiakim, king of Judah, were the signet-ring
+on thy right hand, yet I would tear him off
 \p
-\v 25 Yea, I will delilver thee into the hands of those that
+\v 25 Yea, I will deliver thee into the hands of those that
 seek thy life, and into the hands of those thou dreadest,
 into the hands of Nebuchadrezzar, king of Babylon,
 \v 26 and into the hands of the Chaldeans. Yea, thee and
@@ -3020,7 +3022,7 @@ and they shall dwell in their own land.
 \q For I will bring evil upon them–
 \q2 The year of their visitation.
 \q
-\v 13 In samaria's prophets I witnessed
+\v 13 In Samaria's prophets I witnessed
 \q2 Behaviour that was revolting;
 \q They prophesied by the Baal
 \q2 And seduced My people Israel.
@@ -3049,7 +3051,7 @@ and they shall dwell in their own land.
 \q2 'Tis their own heart's vision they utter,
 \q2 And not what Jehovah hath spoken.
 \q
-\v 17 They assure thos who mock at the word of Jehovah
+\v 17 They assure those who mock at the word of Jehovah
 \q2 That all with them shall be well.
 \q They assure those who follow their own stubborn hearts
 \q2 That no evil shall come upon them.
@@ -3156,8 +3158,8 @@ showed me two baskets of figs set down in front of
 figs, like the figs that are first ripe: the figs in the other
 were very bad, so bad that they could not be eaten."
 \p
-\v 3 Then Jehovah said to me, "What seest thou, Jere-
-miah?" And I answered, "Figs – the good figs very
+\v 3 Then Jehovah said to me, "What seest thou, Jeremiah?"
+And I answered, "Figs – the good figs very
 good, and the bad very bad, so bad that they cannot be
 eaten."
 \p
@@ -3182,8 +3184,8 @@ Jerusalem that are left in this land, and those whose
 an object of consternation among every kingdom in
 the world, a reproach and a proverb, a taunt and a
 curse, in every place to which I shall drive them;
-\v 10 and I will send among them sword, famine and pesti-
-lence, till they perish from the land that I gave to them
+\v 10 and I will send among them sword, famine and pestilence,
+till they perish from the land that I gave to them
 and their forefathers.
 
 
@@ -3202,8 +3204,8 @@ upon Judah, upon the Neighbouring Nations, and upon the World at Large
 \v 1 The message which came to Jeremiah concerning all
 the people of Judah in the fourth year of Jehoiakim,
 the son of Josiah, king of Judah, which was the first
-\v 2 year of Nebuchadrezzar, king of Babylon – the mes-
-sage he delivered to all the people of Judah and all
+\v 2 year of Nebuchadrezzar, king of Babylon – the message
+he delivered to all the people of Judah and all
 the citizens of Jerusalem:
 \p
 \v 3 For twenty-three years – from the thirteenth year
@@ -3218,9 +3220,9 @@ man of you, your wicked ways and your evil behaviour,
 then you shall dwell for ever in the land which Jehovah,
 gave in the ancient time to you and your forefathers.
 \v 6 But do not indulge in the worship or service of other
-gods, and do not provoke Jehovah with the fabri-
-cations of your own hands: this can only injure your-
-\v 7 selves." But you have not listened to me.
+gods, and do not provoke Jehovah with the fabrications
+of your own hands: this can only injure yourselves."
+\v 7 But you have not listened to me.
 
 
 \s Judgment upon Judah and Her Neighbours
@@ -3231,8 +3233,8 @@ cations of your own hands: this can only injure your-
 \v 9 ye have not listened to My words, I will send and
 fetch a clan from the north, and I will bring them
 against this land and its inhabitants and against the
-sorrounding nation. I will devote them to destruc-
-tion so appalling that men shall hiss and revile them
+sorrounding nation. I will devote them to destruction
+so appalling that men shall hiss and revile them
 \v 10 for ever; and I will banish form them the voice of mirth
 and gladness, the voice of bridegroom and bride, the
 sound of the millstones and the light of the lamp.
@@ -3269,7 +3271,7 @@ princes, to be made a desolation, a horror, a scorn,
 the foreign folk; all the kings of the land of Uz, and
 all the kings of the land of the Philistines – Ashkelon,
 \v 21 Gaza, Ekron, and the survivors of Ashdod; Edom,
-\v 22 Moab, and Ammon; all the kings of Tyre and sidon;
+\v 22 Moab, and Ammon; all the kings of Tyre and Sidon;
 and the kings of the coast-land across the sea;
 \v 23 Dedan and Tema and Buz, and all those that have the
 \v 24 corners of their hair clipped; all the kings of Northern
@@ -3300,7 +3302,7 @@ Jehovah will roar from on high,
 \q
 \v 31 Then din shall reach to the end of the earth,
 \q2 For Jehovah doth hold a dispute with the nations;
-\q Yeah, He with all flesh will contend in judgment,
+\q Yea, He with all flesh will contend in judgment,
 \q2 And those that are base He will give to the sword.
 \q
 \v 32 Thus saith Jehovah of Hosts:
@@ -3345,8 +3347,8 @@ Jehovah will roar from on high,
 \v 1 In the beginning of the reign of Jehoiakim, the son of
 Josiah, king of Judah, the message which follows came
 \v 2 (to Jeremiah) from Jehovah: Thus saith Jehovah,
-Take thy stand in the Temple court, and declare with-
-out reservation to all the people of Judah who are come
+Take thy stand in the Temple court, and declare without
+reservation to all the people of Judah who are come
 to worship in the Temple, the whole message that I
 \v 3 have commissioned thee to declare. It may be that
 they will listen and severally abandon their wicked
@@ -3387,8 +3389,8 @@ Jeremiah in his turn addressed himself to the courtiers
 and to the whole body of the people. "It is Jehovah
 Himself," he said, "that has sent me to proclaim upon
 this Temple and city the doom which you have just
-\v 13 heard. If, however, you amend your life and con-
-duct, and listen to the voice of Jehovah your God, then
+\v 13 heard. If, however, you amend your life and conduct,
+and listen to the voice of Jehovah your God, then
 He will relent and cancel His threat of catastrophe.
 \v 14 As for myself, I am in your hands: deal with me as
 \v 15 you think right and proper. But be very sure of this,
@@ -3401,8 +3403,8 @@ priests and the prophets, "This man is not guilty of
 any capital offence; for his message to us has behind
 it the authority of Jehovah our God."
 \p
-\v 17 Them some of the elders, rising to their feet, thus ad-
-\v 18 dressed the people assembled: "In the days of Hezekiah,
+\v 17 Them some of the elders, rising to their feet, thus
+\v 18 addressed the people assembled: "In the days of Hezekiah,
 king of Judah," they said, "Micah of Moresheth was
 prophesying; and this is what he said to all the people
 of Judah:
@@ -3413,8 +3415,8 @@ Like a field shall Zion be ploughed,
 \q2 Like a thickly wooded height.
 \p
 \v 19 Did Hezekiah the king or the people of Judah dream
-of putting him to death? Rather were they not so over-
-come by godly fear that they sued for the favour of
+of putting him to death? Rather were they not so overcome
+by godly fear that they sued for the favour of
 Jehovah, with the result that He relented and cancelled
 His threat of catastrophe? But look at us! Why, we are
 on the verge of involving ourselves in a great calamity."
@@ -3432,8 +3434,8 @@ reached the ears of King Jehoiakim, with all the court
 and the military officials, the king took steps to have
 him put to death. Urijah, however, got wind of his
 purpose, and in terror he took to flight, finally reaching
-\v 22 Egypt; but King Jehoiakim despatched commis-
-sioners to Egypt – Elnathan the son of Achbor, and a few
+\v 22 Egypt; but King Jehoiakim despatched commissioners
+to Egypt – Elnathan the son of Achbor, and a few
 \v 23 others – who removed him from Egypt and brought
 him back to the presence of King Jehoiakim, who
 had him slain with the sword, and his dead body flung
@@ -3460,8 +3462,8 @@ of Josiah, king of Judah, Jeremiah received from
 \v 2 Jehovah the message which follows. Thus spoke
 Jehovah: Make thongs and bars and put them on
 \v 3 thy neck, and send a message to the kings of Edom,
-Moab, Ammon, Tyre, and Sidon, through their am-
-bassadors who have come to Jerusalem to Zedekiah,
+Moab, Ammon, Tyre, and Sidon, through their ambassadors
+who have come to Jerusalem to Zedekiah,
 \v 4 king of Judah, and bid them say to their masters,
 "Thus saith Jehovah of Hosts, the God of Israel:
 \v 5 Convey this message to your masters. I have made
@@ -3492,7 +3494,7 @@ the nation that brings its neck to the yoke of the king of
 Babylon and serves him, I will leave on their own soil,
 which they shall continue to till and occupy."
 \p
-\v 12 A similar message I gave to zedekiah, king of Judah,
+\v 12 A similar message I gave to Zedekiah, king of Judah,
 "If,' said I, "you bring your neck to the yoke of the
 king of Babylon, and serve him and his people, you will
 \v 13 be spared. Why should you and your people die by the
@@ -3523,8 +3525,8 @@ and the stands and the rest of the vessels that are left
 king of Babylon, when he carried Jeconiah, the son of
 Jehoiakim, king of Judah, with all the nobles of Judah
 \v 21 and Jerusalem, from Jerusalem to Babylon. Yes,
-thus saith Jehovah of Hosts, the God of Israel, con-
-cerning the vessels that are left in the Temple and in
+thus saith Jehovah of Hosts, the God of Israel, concerning
+the vessels that are left in the Temple and in
 \v 22 the royal palace and at Jerusalem; To Babylon
 they shall be brought, and there they shall remain till
 the day that I visit them, saith Jehovah; then I will
@@ -3562,8 +3564,8 @@ Johevah fulfil your prophecy and bring back the Temple
 vessels and all the exiles from Babylon to this place!
 \v 7 I ask you, however to listen to this word that I am
 about to speak in your hearing and in the hearing of all
-\v 8 the people. From the beginning the prophets who pre-
-ceded you and me in their messages concerning many
+\v 8 the people. From the beginning the prophets who
+preceded you and me in their messages concerning many
 \v 9 lands and mighty kingdoms, prophesied war. If a
 prophet prophesies peace, it is only when his word has
 been fulfilled that you can be sure that he has had a real
@@ -3585,8 +3587,8 @@ will put on the necks of all these nations will be made
 of iron – a yoke of service to Nebuchadnezzar, king of
 Babylon: for serve him they shall. I have also given
 \v 15 him the beasts of the field." Then Jeremiah said to
-Hananiah, "Listen, Hananiah. You have no com-
-\v 16 mission from Jehovah: you are making this people
+Hananiah, "Listen, Hananiah. You have no commission
+\v 16 from Jehovah: you are making this people
 trust a lie. Therefore thus saith Jehovah: 'Mark this
 well: I will dismiss thee from the face of the earth.
 This very year thou shalt die; for thy words are a
@@ -3633,7 +3635,7 @@ Jehovah.
 \p
 \v 10 For thus saith Jehovah: As soon as Babylon's
 seventy years are accomplished, I will visit you and
-bring you back to this place, in fulfilment of the garcious
+bring you back to this place, in fulfilment of the gracious
 \v 11 promise I made you. For I know the thoughts I cherish
 towards you – thoughts of weal and not of woe – to
 \v 12 bestow upon you a future and a hope. When you
@@ -3723,8 +3725,8 @@ are a disloyalty to Jehovah.
 \v 2 Thus saith Jehovah, the God of Israel: Write all the
 \v 3 words I have spoken to thee in a book. For mark!
 the days are coming, saith Jehovah, when I will restore
-the fortunes of My people Israel and Judah, and re-
-establish them in possession of the land I gave their
+the fortunes of My people Israel and Judah, and
+re-establish them in possession of the land I gave their
 forefathers.
 \p
 \v 4 Now these are the words Jehovah hath spoken
@@ -3757,7 +3759,7 @@ forefathers.
 \q2 O Israel, be not dismayed, saith Jehovah.
 \q For see! I will save both thee and thine offspring
 \q2 From the far distant land where captive ye lie.
-\q And Jacob once more shall have quite and ease
+\q And Jacob once more shall have quiet and ease
 \q2 In his own land, with no one make him afraid;
 \p
 \v 11 For I, saith Jehovah, am with thee to save thee.
@@ -3835,7 +3837,7 @@ forefathers.
 \q
 \v 23 Hark! 'tis Jehovah's tempest,
 \q It goeth forth with fury–
-\q A whirling temptest that whirleth
+\q A whirling tempest that whirleth
 \q2 Full straight for the heads of the wicked.
 \q
 \v 24 The glowing wrath of Jehovah
@@ -4078,7 +4080,7 @@ thrown down again for ever.
 
 
 
-\ms2 During the Siege Jeremiah Displays his Confidence in the Ulimate
+\ms2 During the Siege Jeremiah Displays his Confidence in the Ultimate
 Restoration of his People by Redeeming a Piece of Land Belonging to his
 Family at Anathoth
 
@@ -4159,21 +4161,21 @@ among (other) men signs and wonders (which are
 commemorated) unto this day, and so didst win for
 \v 21 Thyself the renown that is Thine to-day; and Thou
 didst bring Thy people Israel out of the land of Egypt
-by signs and wonders, with mighty hand out-
-\v 22 stretched arm and terrors great; and Thou gavest them
+by signs and wonders, with mighty hand and
+\v 22 outstretched arm and terrors great; and Thou gavest them
 this land which Thou didst swear to their fathers to
 give them – a land flowing with milk and honey – and
 \v 23 they came in and took possession of it. But they would
 not listen to Thy voice, nor live in accordance with Thy
-law; they have left undone all that Thou didst com-
-mand them to do; and so Thou hast brought all this
+law; they have left undone all that Thou didst command
+them to do; and so Thou hast brought all this
 misery upon them.
 \p
 \v 24 Behold how the siege-mounds for storming the city
 are already close upon it, and under the stress of
 sword, famine and pestilence, the city is already as good
-as given into the hands of the Chaldeans that are assail-
-ing it. What Thou hast threatened has come, as
+as given into the hands of the Chaldeans that are assailing
+it. What Thou hast threatened has come, as
 \v 25 Thou Thyself seest. And it was Thou Thyself, O
 Lord Jehovah, who didst command me to buy the land;
 (and this I have done), writing and sealing the deed
@@ -4243,8 +4245,8 @@ this land.
 upon this people all this mass of misery, so surely will I
 bring upon them all the blessings I promise them.
 \v 43 In this land that ye call a desolation, forsaken of man
-and beast and delivered into the hands of the Chal-
-\v 44 deans, fields shall be bought once more. Yes, men
+and beast and delivered into the hands of the Chaldeans,
+\v 44 fields shall be bought once more. Yes, men
 shall buy fields for money, subscribing and sealing the
 deeds, and taking witnesses, in the district of Benjamin
 and the neighbourhood of Jerusalem and the cities of
@@ -4343,7 +4345,7 @@ do sacrifice.
 \v 20 Thus saith Jehovah: Not until ye can annul My covenant with
 Day and Night, so that Day and Night shall come no more at
 \v 21 their appointed time – not until then shall My covenant be
-annulled with David My servant, that a son od his should reign
+annulled with David My servant, that a son of his should reign
 upon his throne; or My covenant with the Levitical priests,
 \v 22 My ministers. Numberless as the host of heaven, measureless
 as the sand of the sea, shall I multiply the descendants of
@@ -4410,7 +4412,7 @@ Slaves: To be Punished by the Liberation of Disaster upon Themselves
 \v 8 The message which came to Jeremiah from Jehovah,
 after the King Zedekiah had covenanted with all the people
 \v 9 in Jerusalem to make a proclamation of liberty – each
-man to set free his Hebrew slave, wether male or
+man to set free his Hebrew slave, whether male or
 female, so that no one of Jewish descent should serve
 \v 10 as slave any longer. Now all the princes and all the
 people kept the covenant they had entered into to
@@ -4426,7 +4428,7 @@ When I brought your forefathers out of the land of
 Egypt, that house of slavery, I Myself made this
 \v 14 covenant that at the end of six years they were to
 release any Hebrew brother who had sold himself to
-them-after six years of service, they were to set him
+them – after six years of service, they were to set him
 free: your forefathers, however, would not listen
 \v 15 or incline their ear to Me. But you have in these days
 acted in a very different spirit; you have done what
@@ -4478,8 +4480,8 @@ Judah, Jeremiah received the following message from
 \v 2 Jehovah: Go to the clan of the Rechabites, talk with
 them, bring them into one of the chambers (of the
 \v 3 Temple) and offer them wine to drink. So I took
-Jaazaniah, the son of Jeremiah, the son of Habaz-
-ziniah, with his brothers and all his sons and the whole
+Jaazaniah, the son of Jeremiah, the son of Habaz-ziniah,
+with his brothers and all his sons and the whole
 \v 4 Rechabite clan, and brought them into the Temple
 chamber belonging to the sons of Hanan, the son of
 Yigdaliah, the man of God, that was adjacent to the
@@ -4521,8 +4523,8 @@ conduct, and no longer indulge in the service of other
 gods, you should continue in the land that I gave your
 forefathers; but you would not incline your ear or
 \v 16 listen to Me. Unlike the descendants of Jonadab the
-son of Rechab, who have steadily observed the in-
-junctions of their ancestor, this people has refused to
+son of Rechab, who have steadily observed the injunctions
+of their ancestor, this people has refused to
 \v 17 listen to Me. Therefore thus saith Jehovah of Hosts,
 the God of Israel: See! I am about to bring upon
 Judah and upon all the citizens of Jerusalem all the
@@ -4559,8 +4561,8 @@ ways, and receive at My hands pardon for their guilt
 and sin.
 \p
 \v 4 Then Jeremiah summoned Baruch, the son of Neriah,
-who wrote down on a book-roll to Jeremiah's dic-
-tation all the messages Jehovah had communicated to
+who wrote down on a book-roll to Jeremiah's dictation
+all the messages Jehovah had communicated to
 \v 5 him. Thereafter Jeremiah gave instructions to
 Baruch in the following terms: "Seeing that I am
 personally under restraint and debarred from access
@@ -4599,8 +4601,8 @@ words he had heard Baruch read out of the book in the
 \v 14 hearing of the people. The whole court accordingly
 despatched a messenger to Baruch, namely one Jehudi,
 the son of Nethaniah, the son of Shelemiah, the son of
-Cushi, with instructions to Baruch to appear, bring-
-ing with him the roll from which he had read in the
+Cushi, with instructions to Baruch to appear, bringing
+with him the roll from which he had read in the
 hearing of the people. So Baruch, the son of Neriah,
 appeared before them with the roll in his hand.
 \p
@@ -4627,15 +4629,15 @@ the king was sitting in the winter house, and the
 \v 23 fire on the brazier was burning before him; and
 every three or four columns that Jehudi read, the king
 would cut up with his penknife and fling into the fire
-that was on the brazier, till the whole roll was con-
-\v 24 sumed in the fire that was on the brazier. But there
+that was on the brazier, till the whole roll was consumed
+\v 24 in the fire that was on the brazier. But there
 was no sense of horror either on the part of the king
 or of any of his ministers as they listened to all these
 \v 25 words, nor did they rend their garments. Elnathan,
 Delaiah, and Gemariah, however, had entreated the
 king not to burn the roll, but he would not listen to
 \v 26 them. Then the king commanded the royal prince
-Jerachmeel, and seraiah, the son of Azriel, and
+Jerachmeel, and Seraiah, the son of Azriel, and
 Shelemiah, the son of Abdeel, to fetch Baruch the scribe
 and Jeremiah the prophet; but Jehovah kept them in
 concealment.
@@ -4649,8 +4651,8 @@ that were on the first roll that was consigned to the
 Jehovah: Thou hast taken it upon thee to burn this
 roll and to demand my reason for recording the threat
 that the king of Babylon would assuredly come and
-\v 30 destroy this land, and clear it of man and beast. There-
-fore thus saith Jehovah concerning Jehoiakim, king of
+\v 30 destroy this land, and clear it of man and beast.
+Therefore thus saith Jehovah concerning Jehoiakim, king of
 Judah: Never a man shall he have to sit upon the
 throne of David; his dead body shall be flung out and
 \v 31 exposed to the heat of day and the cold of night. I
@@ -4662,8 +4664,8 @@ threatened them in vain."
 \v 32 Then Jeremiah took another roll and gave it to
 Baruch the scribe, the son of Neriah, who wrote on it
 to Jeremiah's dictation all the words of the book that
-had been burned by Jehoiakim; and it was supple-
-mented by many messages of a similar kind.
+had been burned by Jehoiakim; and it was supplemented
+by many messages of a similar kind.
 
 
 
@@ -4680,8 +4682,8 @@ mented by many messages of a similar kind.
 \p
 \v 1 Now Zedekiah the son of Josiah was reigning in place
 of Coniah, the son of Jehoiakim, having been set upon
-the throne of Judah by Nebuchadrezzar, king of Baby-
-\v 2 lon; but neither he nor his ministers nor the people
+the throne of Judah by Nebuchadrezzar, king of Babylon;
+\v 2 but neither he nor his ministers nor the people
 of the land gave any heed to the messages Jehovah
 \v 3 had delivered by the prophet Jeremiah. King
 Zedekiah, however, sent Jehucal the son of Shelemiah,
@@ -4691,7 +4693,7 @@ Jeremiah, with the request that he would pray for
 not yet been put in prison, was still coming and
 going among the people.
 \p
-\v 5 The Chaledeans who were engaged in the siege of
+\v 5 The Chaldeans who were engaged in the siege of
 Jerusalem, having received a report that Pharaoh's
 army was advancing from Egypt, abandoned the siege.
 \v 6 Then there came to Jeremiah this message from
@@ -4701,11 +4703,11 @@ Pharaoh's army which is advancing to your aid
 \v 8 shall return to Egypt to their own land; and the
 Chaldeans will come back and assault this city
 \v 9 and take it and burn it with fire. Thus saith Jehovah:
-Do not delude yourselves with the idea that the Chal-
-deans will leave you for good: they will do nothing of
+Do not delude yourselves with the idea that the Chaldeans
+will leave you for good: they will do nothing of
 \v 10 the kind. For even if you defeated the whole
-Chaldean army that is fighting against you, so com-
-pletely that the only survivors were wounded men – a
+Chaldean army that is fighting against you, so completely
+that the only survivors were wounded men – a
 man to a tent– even they would rise up and burn this
 city with fire.
 
@@ -4739,8 +4741,8 @@ dungeon, where he remained for a considerable time.
 
 \p
 \v 17 Then King Zedekiah sent for him and questioned
-him secretly in his house whether there was any com-
-munication from Jehovah. "There is," said Jeremiah;
+him secretly in his house whether there was any
+communication from Jehovah. "There is," said Jeremiah;
 "you will be delivered into the hands of the king of
 \v 18 Babylon. Further," said Jeremiah to the king,
 "what is my crime against you or your ministers or
@@ -4768,7 +4770,7 @@ Rescued by Ebedmelech, a Foreigner
 \p
 \v 1 Now Shephatiah, the son of Mattan, and Gedaliah, the
 son of Pashhur, and Juca, the son of Shelemiah, and
-Pashhur, the son of Malchiah, ahd heard Jeremiah
+Pashhur, the son of Malchiah, and heard Jeremiah
 \v 2 addressing all the people in words like these: "Thus
 saith Jehovah: Whoever remains in this city shall die
 by sword, famine and perstilence; but whoever goes
@@ -4826,14 +4828,14 @@ you not certain to put me to death? besides, any advice
 the king swore the following oath to Jeremiah, "As
 Jehovah liveth, who created this life of ours, I assure
 you solemnly that I will neither put you to death nor
-deliver you into the hands of those men that are seek-
-\v 17 ing your life." Then said Jeremiah to Zedekiah,
+deliver you into the hands of those men that are seeking
+\v 17 your life." Then said Jeremiah to Zedekiah,
 "Thus saith Jehovah, If you surrender voluntarily to
 the officers of the king of Babylon, your life will be
 spared, and this city shall not be burned with fire, but
 \v 18 you and your family will be spared. If, however, you
 refuse to surrender, then this city shall be delivered
-into the handso of the Chaldeans, who will burn it with
+into the hands of the Chaldeans, who will burn it with
 fire; and you shall not escape from their hands."
 \v 19 Then the king said to Jeremiah, "I am afraid of the
 Jews who have gone over to them and subjected to violence."
@@ -4859,8 +4861,8 @@ this city shall be burned with fire."
 \v 24 "Well, then," said the king to him, "let nobody
 know anything of this conversation, or else you are a dead
 \v 25 man. If the courtiers hear that I have been talking
-with you, and come and ask you to tell them un-
-reservedly, on pain of death, what you have been saying
+with you, and come and ask you to tell them unreservedly,
+on pain of death, what you have been saying
 \v 26 to the king and the king to you, then just tell them that
 you were presenting a petition to the king that you
 should not be taken back to Jonathan's house, where
@@ -4910,18 +4912,18 @@ and loaded him with chains to carry him to Babylon.
 \v 8 The palace and the houses of the people the Chaldeans
 burned with fire, and the walls of Jerusalem they
 \v 9 demolished. The rest of the people that were left in the
-city, and the deserters who had gonve over to him, and
-those that werer left of the artificers, Nebuzaradan, the
+city, and the deserters who had gone over to him, and
+those that were left of the artificers, Nebuzaradan, the
 commander of the guard, carried to exile in Babylon.
 \v 10 Some of the poor people who had nothing were left by
 Nebuzaradan, the commander of the guard, in the land
-of Judah, and presented at the same time with vine-
-yards and fields.
+of Judah, and presented at the same time with vineyards
+and fields.
 \p
 \v 11 With regard to Jeremiah, Nebuchadrezzar, king of
-Babylon, had instructed Nebuzardan, the commander
+Babylon, had instructed Nebuzaradan, the commander
 \v 12 of the guard, to do him no harm, but to take and look
-well afer him and treat him according to his own
+well after him and treat him according to his own
 \v 13 instructions. So a messenger was despatched from
 Nebuzaradan, the commander of the guard, and
 Nebuzaradan, the Rab-saris, and Nergalsharezer, the
@@ -4965,8 +4967,8 @@ thy trust in Me.
 
 \p
 \v 1 The message which came to Jeremiah from Jehovah
-after he had been released from Ramah by Nebuzar-
-adan, the commander of the guard, who had found him
+after he had been released from Ramah by Nebuzaradan,
+the commander of the guard, who had found him
 there in chains among the captives of Jerusalem and
 Judah, who were being carried to exile in Babylon.
 \p
@@ -5013,14 +5015,14 @@ gather wine, fruit, and oil, and store them up and live
 \v 11 in the towns you take possession of." Further, all the
 Jews that were in Moab, Ammon, Edom, or elsewhere,
 when they heard that the king of Babylon had granted
-permission to some to remain in Judah and had ap-
-\v 12 pointed Gedaliah the son of Ahikam Governor, they
+permission to some to remain in Judah and had appointed
+\v 12 Gedaliah the son of Ahikam Governor, they
 all returned to Judah from all the places to which they
 had been driven – to Gedaliah at Mizpah – and they
 gathered immense stores of wine and fruit.
 \p
-\v 13 Now Johanan the son of Kareah and all the com-
-manders of the forces in the open field came to Gedaliah
+\v 13 Now Johanan the son of Kareah and all the commanders
+of the forces in the open field came to Gedaliah
 \v 14 at Mizpah, and asked him whether he was aware
 that Baalis king of Ammon had sent Ishmael the son of
 Nethaniah to assasiante him. But Gedaliah would
@@ -5038,7 +5040,7 @@ what you say of Ishmael is not true."
 
 
 \p
-\v 1 In the seventh month, however, Ishamael, the son
+\v 1 In the seventh month, however, Ishmael, the son
 of Nethaniah, the son of Elishama, a member of the
 royal family, accompanied by one of the chief officers of
 the king and ten (other) men, paid a visit to Gedaliah
@@ -5058,8 +5060,8 @@ to be there.
 \v 4 The day after the murder of Gedaliah, of which no
 \v 5 one was yet aware, eighty pilgrims from Shechem,
 Shiloh, and Samaria, with beards shaven, clothes rent
-and gashes (on their bodies), came with vegetable offer-
-ings and frankincense in their hand to present them at
+and gashes (on their bodies), came with vegetable offerings
+and frankincense in their hand to present them at
 \v 6 the house of Jehovah. Ishmael went out from Mizpah
 to meet them, and they were weeping as they went
 along. When he meet them, he invited them to come to
@@ -5078,8 +5080,8 @@ slain.
 \p
 \v 10 Then Ishmael carried away captive all the rest of the
 people that were at Mizpah, the princesses and all the
-people left in Mizpah, whom Nebuzaradan, the com-
-mander of the guard, had committed to the charge of
+people left in Mizpah, whom Nebuzaradan, the commander
+of the guard, had committed to the charge of
 Gedaliah, the son of Ahikam; and he started across to
 \v 11 Ammon. But when Johanan the son of Kareah, and
 all the commanders of the forces that were with him,
@@ -5087,8 +5089,8 @@ all the commanders of the forces that were with him,
 took all their men and set out to attack him; and they
 \v 13a found him by the great waters of Gibeon. All the
 \v 14a people with Ishmael – all that he had carried captive
-\v 13b from Mizpah – when they saw Johanan and the com-
-manders of the forces that were with him, were filled
+\v 13b from Mizpah – when they saw Johanan and the commanders
+of the forces that were with him, were filled
 \v 14b with joy; and turning about, they came back and
 \v 15 joined Johanan. But Ishmael, escaping with eight
 men, repaired to Ammon.
@@ -5099,8 +5101,8 @@ Ishmael had carried away captive from Mizpah, after
 his assassination of Gedaliah the son of Ahikam – men,
 women, and eunuchs, whom he had brought back from
 \v 17 Gibeon. Then they took their journey and stayed
-awhile at the sheepfolds of Chimham in the neighbour-
-hood of Bethlehem, from which they intended to
+awhile at the sheepfolds of Chimham in the neighbourhood
+of Bethlehem, from which they intended to
 \v 18 travel to Egypt; for they were in terror of the
 Chaldeans, because Ishmael had assassinated Gedaliah,
 whom the king of Babylon had appointed Governor of
@@ -5124,8 +5126,8 @@ for them, remnant as they were, to Jehovah his God.
 \v 3 you see with your own eyes. Let Jehovah your God
 tell us the way we should go and the things we should do."
 \v 4 Jeremiah replied, "I have heard you; I promise to
-pray to Jehovah our God, as you request; and what-
-ever be Jehovah's answer I will tell you unreservedly."
+pray to Jehovah our God, as you request; and whatever
+be Jehovah's answer I will tell you unreservedly."
 \v 5 Whereupon they said to Jeremiah, "Jehovah be our
 true and faithful Witness that we will act entirely in
 accordance with any message that Jehovah your God
@@ -5140,7 +5142,7 @@ Johanan and all the commanders of the forces that
 were with him, and all the people, small and great,
 \v 9 and thus he addressed them. "Thus saith Jehovah,
 the God of Israel, to whom you sent me to present your
-\v 10 supplication: If you remain quitely in this land, I will
+\v 10 supplication: If you remain quietly in this land, I will
 build you up and not throw you down; I will plant you
 and not pluck you up: for I am grieved at the misery
 \v 11 I have brought upon you. You are afraid of the king of
@@ -5163,8 +5165,8 @@ there in the land of Egypt, and the hunger that you
 dread shall cling to your heels there in Egypt, and there
 \v 17 ye shall die; and all the men that were determined
 to go and settle in Egypt shall die by the sword, famine,
-and pestilence; not one shall survive or escape the dis-
-\v 18 aster that I will bring upon them. For thus saith
+and pestilence; not one shall survive or escape the
+\v 18 disaster that I will bring upon them. For thus saith
 Jehovah of Hosts, the God of Israel: As Mine anger
 and fury have been poured out upon the inhabitants of
 Jerusalem, so shall My fury be poured out upon you
@@ -5194,7 +5196,7 @@ go and settle."
 \p
 \v 1 When Jeremiah had finished addressing to the
 assembled people all these words with which Jehovah
-\v 2 had commissioned him, Azariah, the son of Hoshaniah,
+\v 2 had commissioned him, Azariah, the son of Hoshaiah,
 and Johanan the son of Kareah and all the defiant and
 insolent men exclaimed to Jeremiah, "You are a liar;
 you have no commission to us from Jehovah to warn
@@ -5256,8 +5258,8 @@ saith Jehovah of Hosts, the God of Israel: Ye have
 seen with your own eyes all the misery that I have
 wrought upon Jerusalem and upon all the cities of
 Judah. Ye see what they are to-day – desolate and
-\v 3 uninhabited – as a consequence of their wicked be-
-haviour which provoked Mine indignation; for they
+\v 3 uninhabited – as a consequence of their wicked
+behaviour which provoked Mine indignation; for they
 went and burned sacrifice in the service of other gods,
 unknown alike to them or to you or your forefathers;
 \v 4 and that, though early and late I had been sending to you
@@ -5272,8 +5274,8 @@ they are to-day.
 \p
 \v 7 Now, therefore, thus saith Jehovah, the God of Hosts,
 the God of Israel: Why are ye doing yourselves this
-great wrong, which can only end in the utter extermin-
-ation of Judah, man and woman, child and babe?
+great wrong, which can only end in the utter
+extermination of Judah, man and woman, child and babe?
 \v 8 Why are ye vexing Me with the fabrications of your
 hands, burning sacrifice to other gods in the land of
 Egypt, where ye have come to settle? All this
@@ -5298,7 +5300,7 @@ sword and by famine, and they shall be an object of
 as I have punished Jerusalem by sword, famine, and
 pestilence, so will I punish those that have made Egypt
 \v 14 their home, that not a man of the remnant of Judah
-which has come to settel in Egypt shall escape or
+which has come to settle in Egypt shall escape or
 survive to return to the land of Egypt for which
 they shall yearn; for none but a fugitive or two
 shall return."
@@ -5335,8 +5337,8 @@ and is it not precisely this that rankled in the mind and
 abominable conduct no longer, with the result that your
 country is become the uninhabited desolation, the
 \v 23 horror, the curse that it is to-day? It is because you
-have offered such sacrifces, sinning against Jehovah, dis-
-obeying the voice of Jehovah, refusing to live in
+have offered such sacrifices, sinning against Jehovah,
+disobeying the voice of Jehovah, refusing to live in
 accordance with His laws. His statutes, His expressed
 will: that is why the misery of to-day is come upon
 you."
@@ -5347,8 +5349,8 @@ assembled: "Listen to the message of Jehovah, all ye
 of Hosts, the God of Israel: Verily you women
 have indeed carried out your solemn resolve faithfully
 to perform the vows you have taken upon you, to burn
-sacrifice to the Queen of Heaven and to pour out drink-
-offerings in her honour. Well, then, keep your word
+sacrifice to the Queen of Heaven and to pour out
+drink-offerings in her honour. Well, then, keep your word
 \v 26 and perform your vows. But listen now to the world of
 Jehovah, all ye Jews who have made Egypt your home.
 Mark this well: I have sworn, saith Jehovah, by My
@@ -5489,14 +5491,14 @@ Judah.
 \q2 Thy mighty one held not his ground,
 \q2 Because down he was thrust by Jehovah.
 \q
-\v 16 The strangers amonf thee are fallen,
-\q2 And prostate, they say each to other,
-\q "Let us flee from the muderous sword,
+\v 16 The strangers among thee are fallen,
+\q2 And prostrate, they say each to other,
+\q "Let us flee from the murderous sword,
 \q2 Let us rise and go back to our people,
 \q2 To the land wherein we were born."
 \q
 \v 17 Call Pharaoh of Egypt "Blusterer,
-\q2 Who hath let ht hour go by."
+\q2 Who hath let the hour go by."
 \q
 \v 18 As live, saith the King, whose name
 \q2 Is Jehovah of Hosts: One shall come
@@ -5557,7 +5559,7 @@ Judah.
 \q2 O Israel, be not dismayed, saith Jehovah.
 \q For see! I will save both thee and thine offspring
 \q2 From the far distant land where captive ye lie.
-\q And Jacob once more shall have quite and ease
+\q And Jacob once more shall have quiet and ease
 \q In his own land, with no one to make him afraid;
 \q
 \v 28 So fear thou not, O Jacob My Servant,
@@ -5659,7 +5661,7 @@ Pharaoh smote Gaza. Thus saith Jehovah:
 \q
 \v 9 Give ye wings unto Moab,
 \q2 For fain would she fly away
-\q From her cities that shll be desolate
+\q From her cities that shall be desolate
 \q2 And empty altogether.
 \q
 \v 10 Cursed be he that doeth
@@ -5668,7 +5670,7 @@ Pharaoh smote Gaza. Thus saith Jehovah:
 \q2 His sword from (shedding) blood.
 \q
 \v 11 From his youth Moab been at ease,
-\q2 On his lees he hath quitely rested–
+\q2 On his lees he hath quietly rested–
 \q Not emptied from vessel to vessel,
 \q2 Nor ever to exile borne;
 \q so his taste remaineth in him,
@@ -5713,14 +5715,14 @@ Pharaoh smote Gaza. Thus saith Jehovah:
 \v 20 "Moab is put to shame:
 \q2 She is broken; howl ye and cry."
 \q
-\v 21 Tell it by the Arnon that Moab is laid waste. Judg-
-\q2 ment is come upon the table-land – upon Holon,
+\v 21 Tell it by the Arnon that Moab is laid waste.
+\q2 Judgment is come upon the table-land – upon Holon,
 \q
-\v 22 Jahzah, and Mephaath, upon Dibon, Nebo, and Beth-
+\v 22 Jahzah, and Mephaath, upon Dibon, Nebo, and Beth-diblathaim,
 \q
-\v 23 diblathaim, upon Kiriathaim, Beth-gamul, and Beth-
+\v 23 upon Kiriathaim, Beth-gamul, and Beth-meon,
 \q
-\v 24 meon, upon Keriyyoth and Bozrah, and all the cities
+\v 24 upon Keriyyoth and Bozrah, and all the cities
 of the land of Moab, far and near.
 \q
 \v 25 Hewn off is the horn of Moab,
@@ -5750,7 +5752,7 @@ her?
 \q2 The falseness of her boasting,
 \q2 And the falseness of her behaviour.
 \q
-\v 31 There shall therfore be wailing in Moab,
+\v 31 There shall therefore be wailing in Moab,
 \q2 Yea, shrieks from all quarters of Moab,
 \q2 And moans for the men of Kir-heres.
 \q
@@ -5758,7 +5760,7 @@ her?
 \q2 Shall be weeping as men weep for Jazer.
 \q Thy branches passed over the sea,
 \q2 They reached as far as Jazer;
-\q On thy summmer fruits and their vintage
+\q On thy summer fruits and their vintage
 \q2 Is the despoiler fallen.
 \q
 \v 33 Gladness and mirth are vanished
@@ -5894,7 +5896,7 @@ her?
 \q2 And his lurking-place uncovered,
 \q2 So that hide himself he cannot.
 \q Destroyed is he to a man
-\q2 By the arm of his brethen and neighbours.
+\q2 By the arm of his brethren and neighbours.
 \q
 \v 11 Leave thine orphans, and I will preserve them;
 \q2 Let thy widows trust in Me.
@@ -6133,7 +6135,7 @@ the prophet.
 \q Shoot your arrows at her without stint,
 \q2 She hath sinned against Jehovah.
 \q
-\v 15 Encirlce her with your war-cry,
+\v 15 Encircle her with your war-cry,
 \q2 Already she hath surrendered;
 \q Her buttresses are fallen,
 \q2 Her walls are torn down.
@@ -6176,13 +6178,13 @@ the prophet.
 \q2 And do all I command, saith Jehovah.
 \q
 \v 22 Hark! the alarum of war,
-\q2 In Chaldea fell destrucion.
+\q2 In Chaldea fell destruction.
 \q How is she hewn and shattered–
 \q2 The Hammer of all the earth.
 \q What a horror among the nations
 \q2 Is Babylon become!
 \q
-\v 24 I sanred thee, and thou hast been taken,
+\v 24 I snared thee, and thou hast been taken,
 \q2 O Babylon, unaware:
 \q Thou art discovered and caught,
 \q2 Because thou hast challenged Jehovah.
@@ -6294,7 +6296,7 @@ the prophet.
 \q2 To the pastures of sheep from the jungle of Jordan,
 \q Even so will I chase them away in a moment,
 \q2 And visit with vengeance their choicest rams.
-\q Wh is like Me? Who will challenge Me?
+\q Who is like Me? Who will challenge Me?
 \q2 What shepherd is there that will face Me?
 \p
 \v 45 Therefore hear what Jehovah hath planned against
@@ -6356,7 +6358,7 @@ the prophet.
 \q2 But past all healing was she;
 \q And so we now will leave her,
 \q2 And each to his own land go;
-\q For her judgement reacheth to heaven,
+\q For her judgment reacheth to heaven,
 \q2 It mounts to the very clouds.
 \q
 \v 10 Jehovah hath shown that the right was ours:
@@ -6394,8 +6396,8 @@ the prophet.
 \q2 The waters roar in the heavens,
 \q And He causeth vapours to rise
 \q2 From the uttermost ends of the earth.
-\q Lightings He made for the rain,
-\q2 And the wind He brings out if His storehouses.
+\q Lightnings He made for the rain,
+\q2 And the wind He brings out of His storehouses.
 \q
 \v 17 How foolish is man with his knowledge!
 \q2 The goldsmith is shamed by his image;
@@ -6470,7 +6472,7 @@ the prophet.
 \q2 That on all sides his city is taken.
 \q
 \v 32 The ferries have been seized,
-\q2 The defences areburned with fire,
+\q2 The defences are burned with fire,
 \q2 And the men of war are confounded.
 \q
 \v 33 For thus saith Jehovah of Hosts,
@@ -6650,7 +6652,7 @@ against the king of Babylon.
 year of his reign Nebuchadrezzar, king of Babylon,
 came with all his forces to storm Jerusalem. They
 pitched their camp against it, and surrounded it with
-\v 5 a siege-wall; so the city was undersiege till the eleventh
+\v 5 a siege-wall; so the city was under siege till the eleventh
 \v 6 year of king Zedekiah. In the ninth day of the fourth
 month – the famine in the city being so severe that
 \v 7 there was no bread for the people of the land – a
@@ -6682,9 +6684,9 @@ forces that were under the commander of the guard.
 who had gone over the king of Babylon, and those
 that were left of the artificers, were carried into exile by
 \v 16 Nebuzaradan the commander of the guard. Some of
-the poorest of the country people were left by Nebuzar-
-adan, the commander of the guard, to act as vine-
-dressers and ploughmen.
+the poorest of the country people were left by Nebuzaradan,
+the commander of the guard, to act as vine-dressers
+and ploughmen.
 \p
 \v 17 The bronze pillars of the Temple, and the stands,
 and the bronze sea that was in the Temple, were broken
@@ -6693,22 +6695,22 @@ in pieces by the Chaldeans, and all the bronze of them
 the shovels and the snuffers and the basons and the
 pans and all the bronze vessels used in the (Temple)
 \v 19 service. The goblets and the snuff-dishes (for the
-lamps) and the basons and the pots and the lamp-
-stands and the pans and the libation bowls – whatever
+lamps) and the basons and the pots and the lamp-stands
+and the pans and the libation bowls – whatever
 was of gold or silver respectively – were removed by the
 \v 20 commander of the guard: – the pillars, two; the sea
 one; and the bronze bulls that supported the sea,
 twelve; and the stands which King Solomon had
 made for the Temple, ten; – vessels the mass of whose
 \v 21 bronze was beyond weight. Each of the pillars was
-twenty-seven feet in height, eighteen feet in circum-
-ference, three inches in thickness, and hollow within.
+twenty-seven feet in height, eighteen feet in circumference,
+three inches in thickness, and hollow within.
 \v 22 It was surmounted by a bronze capital, seven feet and a
-half in height, round which ran network and pome-
-granates of bronze throughout; the (network and)
-\v 23 pomogranate adorment of both pillars was alike. On
-the network round about there were a hundred pome-
-granates in all, of which ninety-six were visible.
+half in height, round which ran network and pomegranates
+of bronze throughout; the (network and)
+\v 23 pomegranate adorment of both pillars was alike. On
+the network round about there were a hundred pomegranates
+in all, of which ninety-six were visible.
 \p
 \v 24 The commander of the guard also took Seraiah the
 chief priest, and Zephaniah the second priest, and the
@@ -6726,10 +6728,10 @@ from her own land into exile.
 \p
 \v 28 These are the people whom Nebuchadrezzar carried
 into exile; in the seventeenth year (of his reign)
-\v 29 three thousand and twenty-three Jews; in the eight-
-eenth year of Nebuchadrezzar, eight hundred and
-\v 30 thirty-two persons from Jerusalem; in the twenty-
-third year of Nebuchadrezzar Nebuzaradan the
+\v 29 three thousand and twenty-three Jews; in the eighteenth
+year of Nebuchadrezzar, eight hundred and
+\v 30 thirty-two persons from Jerusalem; in the twenty-third
+year of Nebuchadrezzar Nebuzaradan the
 commander of the guard carried seven hundred and
 forty-five Jews into exile: – in all, four thousand
 six hundred.


### PR DESCRIPTION
I accomplished most of this by generating a word list and checking out any wrong or suspicious words.  I found and fixed a couple more things in the process, e.g. `\p v 1` near the start.

I also removed all the hyphenated linebreaks.  (In some cases this required some guesswork as to whether to keep the hyphen).
There are now no hyphens at the end of lines (but plenty of m-dashes `–`).

I used the McFadyen scan from https://archive.org/details/jeremiahinmodern00mcfauoft as a reference, mostly referring to the OCR text, occasionally checking the PDF also.

(Most of the mistakes look like keyboard errors to me, suggesting the whole book was typed up at some point, rather than cleaning up an OCR version.)

I notice that in many cases the verse numbers don't appear in the right place on the line (indeed, in some places it came in the middle of hyphenated words).  Or perhaps for poetic verses it could be said that it's the linebreaks that are in the wrong place.

Either way, fixing that is probably a massive, separate task.