### PR TITLE
More Jeremiah fixups

### DIFF
--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -410,7 +410,7 @@ but only in pretence."
 justified herself more than faithless Judah.
 \v 12 Go and
 proclaim these words towards the north and say:
-O backsliding Israel, turn,
+\q O backsliding Israel, turn,
 \q2 I will not look in anger upon thee;
 \q For I am kind, saith Jehovah,
 \q2 I keep not Mine anger for ever.
@@ -1475,9 +1475,9 @@ rather death than life, saith Jehovah of Hosts.
 \q Let the wise man not boast of his wisdom,
 \q2 Let the strong man not boast of his strength;
 \q Let the rich man not boast of his riches,
-\p
+\q2
 \v 24 But in this be the boaster's boast–
-\q2 In insight and knowledge of Me
+\q In insight and knowledge of Me
 \q2 As Jehovah, who over the earth
 \q Doeth kindness and justice and right;
 \q2 For these are the things that I love.
@@ -1514,7 +1514,7 @@ hath spoken to you.
 \q Learn not the ways of the heathen,
 \q2 And be not dismayed at the signs in the sky,
 \q As the heathen are dismayed;
-\p
+\q2
 \v 3 For heathen religion is vapour.
 \q A tree is cut down in the forest
 \q2 And fashioned by craftsman's axe,
@@ -1544,11 +1544,11 @@ hath spoken to you.
 \q
 \v 8 One and all, they are senseless and silly,
 \q2 Instructed of gods that are wooden.
-\p
+\q
 \v 9 With silver beat fine, brought from Tarshish,
-\q And gold that cometh from Ophir–
-\q2 And wrought by the craftsman and goldsmith,
-\q And robed in blue and in purple–
+\q2 And gold that cometh from Ophir–
+\q And wrought by the craftsman and goldsmith,
+\q2 And robed in blue and in purple–
 \q2 The work of skilled men are they all–
 \b
 \q
@@ -2247,7 +2247,7 @@ the son of Hezekiah, king of Judah.
 \q Let not Thine anger tarry.
 \q2 Bethink Thee – it is in Thy cause
 \q That I have been laden with insult.
-\p
+\q2
 \v 16 They spurn Thy words – every man of them.
 \q But to me is Thy word a delight,
 \q2 The very joy of my heart;
@@ -2422,10 +2422,10 @@ other gods; for no favour shall ye have from Me."
 \q With diamond point it is graven
 \q2 On the tablet of their heart,
 \q On the horns of their altars,
-\p
+\q2
 \v 2 On every green tree,
 \q On every high hill,
-\p
+\q2
 \v 3 On the heights in the field.
 \q Thy substance and all thy treasures
 \q2 As spoil I will give,
@@ -2937,8 +2937,8 @@ with fire.
 \p
 \v 11 To the royal house of Judah thy message shall be
 this.
-Hear ye the word of Jehovah.
-\p
+\q Hear ye the word of Jehovah.
+\q2
 \v 12 O household of David, thus saith Jehovah:
 In the morning give righteous judgment,
 \q2 Deliver the man that is plundered
@@ -2993,7 +2993,7 @@ solemnly swear that this house shall be laid in ruins.
 \p
 \v 6 For thus saith Jehovah concerning the palace of the
 king of Judah:
-Though thou art to Me as Gilead,
+\q Though thou art to Me as Gilead,
 \q2 Or the (thick-wooded) summit of Lebanon,
 \q I will turn thee into a desert,
 \q2 An uninhabited city.
@@ -3040,7 +3040,7 @@ this land he shall see no more."
 \v 14 That saith, "I will build me a spacious house,
 \q2 And roomy chambers and windows broad,
 \q With panels of cedar, and painted vermilion,"
-\p
+\q2
 \v 15 Do great cedar palaces make thee a king?
 \q Did not thy father eat and drink,
 \q2 And enjoy his measure of good things?
@@ -3103,6 +3103,7 @@ than the land thou wast born in, and there thou shalt
 die.
 \v 27 Nevermore shall they return to the land to which
 they long to return.
+\q
 \v 28 Hath this man Coniah become
 \q2 Like a figure one smasheth in scorn,
 \q2 Or a vessel that no man doth care for?
@@ -3264,7 +3265,7 @@ and they shall dwell in their own land.
 \v 26 Will the heart of the prophets not turn
 \q2 That prophesy lies, and that prophesy
 \q Nought but their own heart's delusions,
-\p
+\q2
 \v 27 And think to drive My name
 \q Clean out of the minds of My people
 \q2 By the dreams that they tell one another,
@@ -3495,7 +3496,7 @@ of the earth, saith Jehovah of Hosts.
 \p
 \v 30 As for thee, let thy prophetic message to them be
 this:
-Jehovah will roar from on high,
+\q Jehovah will roar from on high,
 \q2 He will utter His voice from His holy abode;
 \q Against His own fold He will mightily roar,
 \q2 He will lift a "hurrah" like the men at the vintage
@@ -4632,7 +4633,7 @@ shepherds), saith Jehovah.
 perform My gracious promise to the households of Israel and
 Judah.
 \v 15 In those days and at that time
-I will raise up for David a righteous shoot,
+\q I will raise up for David a righteous shoot,
 \q2 Who shall execute justice and right in the land.
 \q
 \v 16 In those days shall Judah be crowned with salvation,
@@ -5870,6 +5871,7 @@ in the fourth year of Jehoiakim, the son of Josiah, king
 of Judah.
 \v 2 "This, Baruch, is the message to thee from
 Jehovah, the God of Israel.
+\q
 \v 3 Thou hast said, 'Woe is me! for Jehovah
 \q2 to my pain hath added sorrow;
 \q With groaning I am weary,

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -3893,6 +3893,8 @@ from all the nations and places to which I have driven you,
 saith Jehovah, and I will bring you back to the place from
 which I carried you into exile.
 \v 15 But Jehovah, you say, has raised up for you prophets
+in Babylon.
+\b
 \p
 \v 16 For thus saith Jehovah concerning the king who sits on
 the throne of David, and concerning all the people whose home
@@ -3913,7 +3915,7 @@ refused to listen, saith Jehovah.
 Jehovah's message, all of you exiles whom I have sent from
 Jerusalem to Babylon.
 \b
-in Babylon.
+\p
 \v 21 Well, thus saith Jehovah of Hosts, the
 God of Israel, concerning Ahab the son of Kolaiah and
 Zedekiah the son of Maaseiah, who preach to you a lie

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -59,7 +59,7 @@ Jerusalem were swept into exile.
 \q2 "What seest thou there, Jeremiah?" (said the Voice).
 \q
 \v 12 "A branch of an almond tree," I answered. "Thou
-\q hast seen truly," said Jehovah," for I am watching?
+\q hast seen truly," said Jehovah," for I am watching
 \q over My purpose, to perform it."
 
 \ms2 The Vision of the Caldron of War
@@ -339,7 +339,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q2 Can she ever again be his?
 \q Is such a woman as she
 \q2 Not altogether polluted?
-\q Bit thou hast played the harlot
+\q But thou hast played the harlot
 \q2 With many and many a lover;
 \q And canst thou dare to dream
 \q2 Of returning to Me, saith Jehovah?
@@ -373,7 +373,7 @@ Voice). "A boiling pot," I answered, "facing the
 \v 6 In the days of the King Josiah Jehovah said to me:
 "Hast thou seem what backsliding Israel did? She
 went up on every high mountain and under every
-\v 7 green tree and ther she played the harlot. I had
+\v 7 green tree and there she played the harlot. I had
 hoped that, after all this, she would return to Me. But
 no! she did not return. Her faithless sister Judah
 \v 8 saw that I had put backsliding Israel away because of
@@ -780,7 +780,7 @@ your forefathers for an inheritance.
 \v 23 But these people are stubborn, defiant in heart,
 \q2 They are turned aside and gone.
 \q
-\v 24 For they do bot say in their hearts,
+\v 24 For they do not say in their hearts,
 \q2 "Let us fear Jehovah, our God,
 \q Who giveth the rain in its season,
 \q2 The early and latter rain,
@@ -834,9 +834,9 @@ your forefathers for an inheritance.
 \v 3 But shepherds shall come to assail her,
 \q2 They and their flocks together;
 \q They shall pitch their tents around about her,
-\q2 And graze on her, each were he camps.
+\q2 And graze on her, each where he camps.
 \q
-\v 4 "Prepare ye war agaisnt her;
+\v 4 "Prepare ye war against her;
 \q2 Up! let us storm her at noon-day."
 \q "Alas! for the day declineth,
 \q2 The shadows of evening are lengthening."
@@ -1058,7 +1058,7 @@ to make cakes to the Queen of Heaven, and to pour
 out drink-offerings to other gods, in order to vex Me.
 \v 19 Is it I, then, saith Jehovah, whom they are vexing?
 is it not rather themselves, doomed as they are to
-\v 20 bring confusion upon their own faces/. Therefore,
+\v 20 bring confusion upon their own faces? Therefore,
 thus saith the Lord Jehovah, "My anger and My
 fury shall be poured out upon this place, upon man
 and beast, upon trees of the field and fruit of the ground,
@@ -1448,7 +1448,7 @@ household of Israel is uncircumcised in heart.
 \q2 Instructed of gods that are wooden.
 \p
 \v 9 With silver beat fine, brought from Tarshish,
-\q And gold that cometh form Ophir–
+\q And gold that cometh from Ophir–
 \q2 And wrought by the craftsman and goldsmith,
 \q And robed in blue and in purple–
 \q2 The work of skilled men are they all–
@@ -1579,7 +1579,7 @@ the worship of other gods: the households of Israel
 and Judah alike have broken the covenant I made with
 \v 11 their forefathers. Therefore thus saith Jehovah:
 Mark this – I will bring upon them a disaster which they
-shall be powerless to escape; and when they cry to Me, U
+shall be powerless to escape; and when they cry to Me, I
 \v 12 will turn a deaf ear. Then the cities of Judah and the
 inhabitants of Jerusalem shall go and cry to the gods to
 whom they burn sacrifice; but no help shall they get
@@ -1773,7 +1773,7 @@ bidden me, and I put it on my loins.
 \v 3 Then a second message from Jehovah came to me,
 \v 4 telling me to take the waistcloth I had bought, that
 was on my loins, and to proceed to Parah and bury it
-\v 5 there in a chink of the rock. So I went and burried it
+\v 5 there in a chink of the rock. So I went and buried it
 \v 6 at Parah, as Jehovah had charged me. Many days
 after, Jehovah told me to proceed to Parah and remove
 the waistcloth which He had charged me to bury there.
@@ -2815,7 +2815,7 @@ of exploitation from the clutch of the oppressor, refrain
 from all wrong and violence to the resident foreigner, the
 fatherless and the widow, and shed no innocent blood
 \v 4 in this place. If you carry out this policy faithfully,
-then kings upon the throne of David shall pass through t
+then kings upon the throne of David shall pass through
 the gates of this house, riding in chariots and on horses
 \v 5 –they, their ministers and their people. But if you
 ignore this message (of Mine), then, saith Jehovah, I
@@ -2919,7 +2919,7 @@ this land he shall see no more."
 \p
 \v 24 As truly as I live, saith Jehovah, though Coniah,
 the son of Jehoiakim, king of Judah, were the signet-ring
-on thy right hand, yet I would tear him off
+on thy right hand, yet I would tear him off.
 \p
 \v 25 Yea, I will deliver thee into the hands of those that
 seek thy life, and into the hands of those thou dreadest,
@@ -3233,9 +3233,9 @@ of your own hands: this can only injure yourselves."
 \v 9 ye have not listened to My words, I will send and
 fetch a clan from the north, and I will bring them
 against this land and its inhabitants and against the
-sorrounding nation. I will devote them to destruction
+surrounding nation. I will devote them to destruction
 so appalling that men shall hiss and revile them
-\v 10 for ever; and I will banish form them the voice of mirth
+\v 10 for ever; and I will banish from them the voice of mirth
 and gladness, the voice of bridegroom and bride, the
 sound of the millstones and the light of the lamp.
 \v 11 This whole land shall be a waste and a horror, and
@@ -3495,7 +3495,7 @@ Babylon and serves him, I will leave on their own soil,
 which they shall continue to till and occupy."
 \p
 \v 12 A similar message I gave to Zedekiah, king of Judah,
-"If,' said I, "you bring your neck to the yoke of the
+"If," said I, "you bring your neck to the yoke of the
 king of Babylon, and serve him and his people, you will
 \v 13 be spared. Why should you and your people die by the
 sword, famine and pestilence, with which Jehovah has
@@ -3593,7 +3593,7 @@ trust a lie. Therefore thus saith Jehovah: 'Mark this
 well: I will dismiss thee from the face of the earth.
 This very year thou shalt die; for thy words are a
 \v 17 disloyalty to Jehovah.'" And that very year, in the
-seventh month, the prophet Hananaiah died.
+seventh month, the prophet Hananiah died.
 
 
 
@@ -3785,7 +3785,7 @@ forefathers.
 \q I have struck thee as foemen strike,
 \q2 With chastisement unpitying,
 \q Because of thy manifold guilt
-\q2 And thy sins` that are grown so mighty.
+\q2 And thy sins that are grown so mighty.
 \q
 \v 15 Why criest thou over thy wound,
 \q2 That thy pain is past all healing?
@@ -3848,7 +3848,7 @@ forefathers.
 
 
 
-\s Israel's Happy Return form Exile
+\s Israel's Happy Return from Exile
 
 
 \c 31
@@ -4391,7 +4391,7 @@ the king of Babylon eye to eye, and speak to him face
 Zedekiah, king of Judah, to the message of Jehovah:
 Thus saith Jehovah concerning thee: Thou shalt not
 \v 5 die by the sword, but thou shalt die in peace. (Sweet
-spices) shall be burned for thee, as for thine ancerstors
+spices) shall be burned for thee, as for thine ancestors
 before thee, and lamentations shall be made for thee
 with "Ah! Lord," for I, saith Jehovah, have spoken
 the word.
@@ -4622,7 +4622,7 @@ Secretary, they visited the king in his apartment,
 and reported the whole matter to him.
 \p
 \v 21 The king then despatched Jehudi to fetch the roll;
-and, when he had brought it form Elishama's chamber,
+and, when he had brought it from Elishama's chamber,
 he read it in the hearing of the king and of all the
 \v 22 courtiers who were in attendance upon him. Now
 the king was sitting in the winter house, and the
@@ -4803,7 +4803,7 @@ he will die of hunger on the spot, for there is no more
 Ebedmelech to take with him three me and pull
 Jeremiah out of the cistern before he perished.
 \v 11 Ebedmelech, accordingly, taking the men with him,
-went to the palace, and secured form (a lumber room)
+went to the palace, and secured from (a lumber room)
 underneath the treasury some torn and tattered rags,
 and let them down by ropes to Jeremiah into the
 \v 12 cistern. Then he told Jeremiah to put the torn and

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -486,7 +486,7 @@ your forefathers for an inheritance.
 \q2 We and our fathers from youth
 \q2 Even unto this very day;
 \q And we have not hearkened at all
-\q To the voice of Jehovah our God."
+\q2 To the voice of Jehovah our God."
 
 
 
@@ -833,7 +833,7 @@ your forefathers for an inheritance.
 \q2 the weeks appointed for harvest."
 \q
 \v 25 This order your sins have disturbed,
-\q Your crimes have withheld from you blessing.
+\q2 Your crimes have withheld from you blessing.
 \q
 \v 26 For among My people are knaves,
 \q2 Who set snares and with traps catch men.
@@ -946,7 +946,7 @@ your forefathers for an inheritance.
 \q
 \v 14 They would heal the hurt of My people,
 \q2 As though it were but slight;
-\q2 "It is well, it is well," they say,
+\q "It is well, it is well," they say,
 \q2 "When it is anything but well."
 \b
 \q
@@ -4305,7 +4305,7 @@ concerning Israel and Judah.
 \q I will set My law in their bosom,
 \q2 And write it upon their heart,
 \q And I will be their God,
-\q3 And they shall be My people.
+\q2 And they shall be My people.
 \b
 \q
 \v 34 No more need any teach

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -1499,10 +1499,6 @@ household of Israel is uncircumcised in heart.
 
 
 
-\ms2 The Approaching Doom of Exile
-
-
-
 \ms2 The Folly of Fearing the Impotent and Unreal Gods of the Heathen
 
 
@@ -1581,6 +1577,10 @@ hath spoken to you.
 \q2 His God is the Framer of all things:
 \q2 Jehovah of Hosts is His name.
 \b
+
+
+
+\ms2 The Approaching Doom of Exile
 \q
 \v 17 Take up thy pack from the ground,
 \q2 (O Jerusalem), that sittest beleaguered.

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -17,7 +17,8 @@ the district of Benjamin.
 \p
 \v 2 A message came to him from Jehovah in the
 thirteenth year of the reign of Josiah, the son of Amon,
-\v 3 king of Judah; and (such messages) continued to
+king of Judah;
+\v 3 and (such messages) continued to
 come to him in the days of Jehoiakim, the son of
 Josiah, king of Judah, and up to the end of the
 eleventh year of Zedekiah, the son of Josiah, king of
@@ -68,8 +69,8 @@ Jerusalem were swept into exile.
 \v 13 Then there came to me a second message from
 Jehovah. "What seest thou now?" (said the
 Voice). "A boiling pot," I answered, "facing the
-\q
-\v 14 north." Then Jehovah said to me:
+north."
+\v 14 Then Jehovah said to me:
 \q From the north shall disaster break forth
 \q2 Over all that inhabit the land.
 \q
@@ -89,7 +90,7 @@ Voice). "A boiling pot," I answered, "facing the
 
 \ms2 The Divine Summons and the Divine Assurance
 \q
-\v As for thee, gird up thy loins,
+\v 17 As for thee, gird up thy loins,
 \q2 Arise and declare unto them
 \q2 Whatsoever I command thee.
 \q Let the sight of them not dismay thee,
@@ -102,7 +103,7 @@ Voice). "A boiling pot," I answered, "facing the
 \q The kings and the courtiers of Judah,
 \q2 The priests and the folk of the land.
 \q
-\v They will fight thee, but thou shalt be victor:
+\v 19 They will fight thee, but thou shalt be victor:
 \q2 For I – saith Jehovah most solemnly–
 \q2 I will be with thee to save thee.
 
@@ -373,15 +374,18 @@ Voice). "A boiling pot," I answered, "facing the
 \v 6 In the days of the King Josiah Jehovah said to me:
 "Hast thou seem what backsliding Israel did? She
 went up on every high mountain and under every
-\v 7 green tree and there she played the harlot. I had
+green tree and there she played the harlot.
+\v 7 I had
 hoped that, after all this, she would return to Me. But
 no! she did not return. Her faithless sister Judah
 \v 8 saw that I had put backsliding Israel away because of
 her adultery, and that I had given her a bill of divorce;
 nevertheless faithless Judah was not at all afraid, but
-\v 9 she too went and played the harlot, defiling the land
+she too went and played the harlot,
+\v 9 defiling the land
 by her wanton whoredom, and committing adultery
-\v 10 with stones and stocks. Nevertheless, when faithless
+with stones and stocks.
+\v 10 Nevertheless, when faithless
 Judah turned to Me, it was not with her whole heart,
 but only in pretence."
 
@@ -391,7 +395,8 @@ but only in pretence."
 
 \p
 \v 11 Then Jehovah said to me, "Backsliding Israel has
-\v 12 justified herself more than faithless Judah. Go and
+justified herself more than faithless Judah.
+\v 12 Go and
 proclaim these words towards the north and say:
 O backsliding Israel, turn,
 \q2 I will not look in anger upon thee;
@@ -408,9 +413,11 @@ O backsliding Israel, turn,
 \v 14 Return, ye backsliding children, saith Jehovah,
 for I am your husband and lord; and I will take
 one of you from each city and two from each clan,
-\v 15 and I will bring you to Zion, and give you rulers after
+and I will bring you to Zion,
+\v 15 and give you rulers after
 My own mind, who shall tend you with wisdom and
-\v 16 skill. And when in those days you have grown
+skill.
+\v 16 And when in those days you have grown
 numerous and fruitful in the land, saith Jehovah, men
 shall speak no more of the ark of the covenant of
 Jehovah; it shall never enter their minds, they will
@@ -420,7 +427,8 @@ make another.
 \v 17 At that time Jerusalem shall be called the Throne
 of Jehovah, and all the nations shall gather thereto;
 they shall follow no more the stubbornness of their
-\v 18 evil hearts. In those days the household of Judah
+evil hearts.
+\v 18 In those days the household of Judah
 shall join the household of Israel, and together they
 shall come from the north land to the land that I gave
 your forefathers for an inheritance.
@@ -1007,26 +1015,32 @@ your forefathers for an inheritance.
 \v 2 Take thy stand at the gate of the Temple, and there
 make the following proclamation. Say, Listen to
 this message from Jehovah, all ye men of Judah that
-\v 3 enter these gates to worship Jehovah. Thus saith
+enter these gates to worship Jehovah.
+\v 3 Thus saith
 Jehovah of Hosts, the God of Israel, Amend your ways
 and your doings, and I will guarantee this place as your
-\v 4 permanent home. But put no trust in lying
+permanent home.
+\v 4 But put no trust in lying
 messengers, who say: "This is the Temple of Jehovah, the
-\v 5 Temple of Jehovah, the Temple of Jehovah." For if
+Temple of Jehovah, the Temple of Jehovah."
+\v 5 For if
 you really amend your ways and your doings: if
 you really do justice as between man and man;
 \v 6 if you abstain from the oppression of the resident
 foreigner, the fatherless and the widow, from the shedding
 of innocent blood in this place, and from devotion
-\v 7 to other gods to your own hurt, then I will guarantee
+to other gods to your own hurt,
+\v 7 then I will guarantee
 you a home here for all time in the land that I gave
 your forefathers.
 \p
 \v 8 But see, you are putting your trust in doctrines that
-\v 9 are as profitless as they are false. What! you commit
+are as profitless as they are false.
+\v 9 What! you commit
 theft, murder, adultery, perjury, you burn sacrifice
 to the Baal, you run after other gods that are
-\v 10 strange to you; and then you (have the hardihood
+strange to you;
+\v 10 and then you (have the hardihood
 to) come and stand before me in this House which is
 called by My name, and say, "Now we are safe" – in
 order, forsooth, to carry on all these abominations.
@@ -1037,28 +1051,34 @@ I – saith Jehovah – I have not been blind to all this.
 \v 12 I would ask you to visit My sanctuary in Shiloh,
 where I put My name at the first, and see what the
 wickedness of My people Israel constrained Me to do
-\v 13 to it. And so it will be now, saith Jehovah. Because
+to it.
+\v 13 And so it will be now, saith Jehovah. Because
 you have perpetrated all these anormities, in defiance
 of My most earnest and repeated words, and have
-\v 14 refused to respond to My call, therefore this Temple
+refused to respond to My call,
+\v 14 therefore this Temple
 in which you repose your trust – called by My name
 though it be – and the place that I gave to you and
 your forefathers, I will consign to the same fate as
-\v 15 overtook Shiloh; and I will hurl you out of My sight
+overtook Shiloh;
+\v 15 and I will hurl you out of My sight
 as I have hurled your brethren, the whole race of
 Ephraim.
 \p
 \v 16 As for thyself, offer no prayer for this people, raise
 no cry or prayer on their behalf, and make no intercession
-\v 17 to Me, for I will not listen to thee. Seest thou
+to Me, for I will not listen to thee.
+\v 17 Seest thou
 not what they are doing in the cities of Judah and in
-\v 18 the streets of Jerusalem? The children gather wood,
+the streets of Jerusalem?
+\v 18 The children gather wood,
 the fathers kindle the fire, and the women knead dough,
 to make cakes to the Queen of Heaven, and to pour
 out drink-offerings to other gods, in order to vex Me.
 \v 19 Is it I, then, saith Jehovah, whom they are vexing?
 is it not rather themselves, doomed as they are to
-\v 20 bring confusion upon their own faces? Therefore,
+bring confusion upon their own faces?
+\v 20 Therefore,
 thus saith the Lord Jehovah, "My anger and My
 fury shall be poured out upon this place, upon man
 and beast, upon trees of the field and fruit of the ground,
@@ -1067,26 +1087,32 @@ and it shall blaze in unquenchable flame."
 \v 21 Thus saith Jehovah of Hosts, the God of Israel,
 Put the flesh of your burnt-offerings and your
 (other) sacrifices together, and make a common meal
-\v 22 of them both alike; for on the day that I brought your
+of them both alike;
+\v 22 for on the day that I brought your
 forefathers out of the land of Egypt, I gave them no
 commandment nor did I utter a syllable with regard to
-\v 23 burnt offering or sacrifice. But the commandment I
+burnt offering or sacrifice.
+\v 23 But the commandment I
 gave them was this: Listen, I said, to My voice, and
 then I will be your God and you shall be My people,
 and take My commandments as the standard of all
-\v 24 your life – this is the way to prosperity. But, instead
+your life – this is the way to prosperity.
+\v 24 But, instead
 of inclining their ear and listening, they followed the
 dictates of their own stubborn and wicked hearts; they
-\v 25 went backwards instead of forwards. Ever since your
+went backwards instead of forwards.
+\v 25 Ever since your
 forefathers came out of the land of Egypt, every day up
 to this very day I have been sending you early and late
-\v 26 all My servants the prophets. Instead, however,
+all My servants the prophets.
+\v 26 Instead, however,
 of inclining their ear, they stiffened their necks and
 behaved worse than their forefathers.
 \p
 \v 27 This, then, is the message thou art to address to
 them, though they will not listen to thee, nor respond
-\v 28 to thy call – thy message is to be this:
+to thy call –
+\v 28 thy message is to be this:
 \q This is the folk that refused to listen
 \q2 To the voice of Jehovah their God–
 \q2 That refused to accept correction.
@@ -1115,9 +1141,11 @@ into My mind.
 when it shall be no more called Topheth, nor the Valley
 of the son of Hinnom, but the Valley of Slaughter, and
 Topheth shall be used as a burial-place for want of
-\v 33 room (elsewhere). The dead bodies of this people
+room (elsewhere).
+\v 33 The dead bodies of this people
 shall be devoured by the birds of the air and the beasts
-\v 34 of the earth, and none shall scare them away. In the
+of the earth, and none shall scare them away.
+\v 34 In the
 cities of Judah and on the streets of Jerusalem I will
 still the voice of mirth and gladness, and the voice of
 bridegroom and bride; for the land shall become a waste.
@@ -1131,12 +1159,14 @@ bridegroom and bride; for the land shall become a waste.
 \v 1 At the time, saith Jehovah, they shall bring out of
 their graves the bones of the kings, the princes, the
 priests, and the prophets, of Judah, and of the inhabitants
-\v 2 of Jerusalem, and they shall spread them
+of Jerusalem,
+\v 2 and they shall spread them
 before the sun and the moon and all the host of heaven,
 whom they loved and served and followed and sought
 and worshipped; and they shall remain ungathered
 and unburied, they shall be for dung on the face of the
-\v 3 ground. And in all places to which I have driven them,
+ground.
+\v 3 And in all places to which I have driven them,
 every man that is left of this evil family would choose
 rather death than life, saith Jehovah of Hosts.
 
@@ -1394,7 +1424,8 @@ rather death than life, saith Jehovah of Hosts.
 \p
 \v 25 Mark this well, saith Jehovah: days are coming
 when I will punish all those that, though circumcised
-\v 26 (in flesh) are uncircumcised (in heart) – Egypt, Judah,
+(in flesh) are uncircumcised (in heart) –
+\v 26 Egypt, Judah,
 Edom, Ammon, Moab, and all those denizens of the
 wilderness that have the corners of their hair clipped;
 for while all the nations are uncircumcised, the whole
@@ -1413,7 +1444,8 @@ household of Israel is uncircumcised in heart.
 \q
 \v 1 Listen, O household of Israel, to the word which Jehovah
 \q2
-\v 2 hath spoken to you. Thus saith Jehovah:
+hath spoken to you.
+\v 2 Thus saith Jehovah:
 \q Learn not the ways of the heathen,
 \q2 And be not dismayed at the signs in the sky,
 \q As the heathen are dismayed;
@@ -1545,14 +1577,17 @@ household of Israel is uncircumcised in heart.
 \p
 \v 2 "Listen to the words of this covenant, and declare
 them to the men of Judah and the inhabitants of
-\v 3 Jerusalem. Say to them, Thus saith Jehovah, the God
+Jerusalem.
+\v 3 Say to them, Thus saith Jehovah, the God
 of Israel: Accursed be the man that refuses to listen
-\v 4 to the words of the covenant with which I charged your
+to the words of the covenant
+\v 4 with which I charged your
 forefathers on the day that I brought them out of that
 iron furnace, the land of Egypt. I promised them then
 that, if they obeyed My voice, and conformed to all
 My commandments, they should be My people and I
-\v 5 would be their God, and thus the oath would be
+would be their God,
+\v 5 and thus the oath would be
 established that swore to their forefathers – to give them
 a land flowing with milk and honey, as it is this day."
 Then I answered and said, "Amen, Jehovah."
@@ -1560,10 +1595,12 @@ Then I answered and said, "Amen, Jehovah."
 \v 6 Jehovah then said to me, "Make this proclamation
 throughout the cities of Judah and in the streets of
 Jerusalem: Listen to the words of this covenant and
-\v 7 act upon them. For early and late, ever since the day
+act upon them.
+\v 7 For early and late, ever since the day
 that I brought your forefathers out of the land of
 Egypt up to this day, I have been earnestly adjuring
-\v 8 them to listen to My voice; but instead of obediently
+them to listen to My voice;
+\v 8 but instead of obediently
 inclining their ear, every man of them followed the
 dictates of his own wicked and stubborn heart; so I
 brought upon them all the threats of this covenant
@@ -1572,18 +1609,22 @@ failed to observe."
 \p
 \v 9 Further Jehovah said to me, "The people of Judah
 and the inhabitants of Jerusalem have been engaged in
-\v 10 a manifest conspiracy (against Me). They have
+a manifest conspiracy (against Me).
+\v 10 They have
 reverted to the sins of their forefathers who refused to
 listen to My words, and they are actually indulging in
 the worship of other gods: the households of Israel
 and Judah alike have broken the covenant I made with
-\v 11 their forefathers. Therefore thus saith Jehovah:
+their forefathers.
+\v 11 Therefore thus saith Jehovah:
 Mark this – I will bring upon them a disaster which they
 shall be powerless to escape; and when they cry to Me, I
-\v 12 will turn a deaf ear. Then the cities of Judah and the
+will turn a deaf ear.
+\v 12 Then the cities of Judah and the
 inhabitants of Jerusalem shall go and cry to the gods to
 whom they burn sacrifice; but no help shall they get
-\v 13 from them in the day of their calamity: for your gods,
+from them in the day of their calamity:
+\v 13 for your gods,
 O Judah, are as numerous as your cities; and as
 numerous as the streets of Jerusalem are the altars you
 have set up for sacrifice in the scandalous worship
@@ -1767,14 +1808,18 @@ indulged, by burning sacrifice to the Baal."
 \p
 \v 1 Jehovah told me to go and buy a linen waistcloth and
 put it on my loins, taking care not to let it get into
-\v 2 water. So I bought a waistcloth, as Jehovah had
+water.
+\v 2 So I bought a waistcloth, as Jehovah had
 bidden me, and I put it on my loins.
 \p
 \v 3 Then a second message from Jehovah came to me,
-\v 4 telling me to take the waistcloth I had bought, that
+telling me
+\v 4 to take the waistcloth I had bought, that
 was on my loins, and to proceed to Parah and bury it
-\v 5 there in a chink of the rock. So I went and buried it
-\v 6 at Parah, as Jehovah had charged me. Many days
+there in a chink of the rock.
+\v 5 So I went and buried it
+at Parah, as Jehovah had charged me.
+\v 6 Many days
 after, Jehovah told me to proceed to Parah and remove
 the waistcloth which He had charged me to bury there.
 \v 7 Then I went to Parah and dug out and took the linen
@@ -1784,7 +1829,8 @@ nothing.
 \p
 \v 8 Then there came to me this word from Jehovah:
 \v 9 Thus saith Jehovah, Ruin like this I will bring upon the
-\v 10 soaring pride of Judah and Jerusalem. As for these
+soaring pride of Judah and Jerusalem.
+\v 10 As for these
 depraved people who, refusing to listen to My words,
 follow the dictates of their own stubborn hearts and
 indulge in the worship and service of other gods – let
@@ -1804,12 +1850,14 @@ not listen.
 \v 12 Take to them therefore this message: Thus saith
 Jehovah the God of Israel, "Every jar must be filled with
 wine." And if they say to thee, "Why, of course we
-\v 13 know that every jar must be filled with wine," then this
+know that every jar must be filled with wine,"
+\v 13 then this
 is what thou shalt say to them: Thus saith Jehovah:
 Soon – mark it well – I will fill with drunkenness all
 the inhabitants of this land – the kings that sit upon
 the throne of David, the priests, the prophets, and all
-\v 14 the inhabitants of Jerusalem; and I will dash them,
+the inhabitants of Jerusalem;
+\v 14 and I will dash them,
 saith Jehovah, one against another, fathers and sons
 together. I will neither spare nor pity: no compassion
 shall restrain Me from destroying them.
@@ -1962,7 +2010,8 @@ shall restrain Me from destroying them.
 \q
 \v 11 And Jehovah said to me: Offer no prayer for the
 \q
-\v 12 welfare of this people. When they fast, I will be deaf
+welfare of this people.
+\v 12 When they fast, I will be deaf
 \q to their cry; when they offer burnt-offerings and
 \q cereal offerings, I will not accept them. By sword,
 \q by famine, by pestilence, I will consume them.
@@ -1987,12 +2036,14 @@ preaching lies in My name. I never sent them; they
 have no commission from Me; not a word have I
 spoken to them. What thy preach to you is nothing
 but a tissue of lying visions and idle divinations and
-\v 15 inventions of their own deceitful hearts. This
+inventions of their own deceitful hearts.
+\v 15 This
 therefore is the message of Jehovah concerning those
 prophets who, without any commission from Me, are
 ceaselessly preaching that this land will never suffer
 from sword or famine: by sword and famine shall
-\v 16 those very prophets themselves be consumed, and the
+those very prophets themselves be consumed,
+\v 16 and the
 people they preach to shall be flung out in the streets
 of Jerusalem as victims of sword and famine, and they
 shall lie unburied – themselves, their wives, their sons,
@@ -2063,7 +2114,8 @@ them.
 \q (of destroyers) – the sword to slay, the dogs to tear,
 \q the birds of the air to devour, and the beasts of the
 \q
-\v 4 earth to destroy; and I will make them an object of
+earth to destroy;
+\v 4 and I will make them an object of
 \q Consternation to every kingdom in the world, in return
 \q for all the evil wrought in Jerusalem by Manasseh,
 \q the son of Hezekiah, king of Judah.
@@ -2229,14 +2281,17 @@ them.
 they will ask thee why Jehovah has doomed them to all
 this misery. "What is our guilt," they will say, "and
 what is the sin we have committed against Jehovah our
-\v 11 God?" Tell them then, "Jehovah doth solemnly
+God?"
+\v 11 Tell them then, "Jehovah doth solemnly
 declare: it is because your fathers abandoned Me
 for the worship and the service of other gods; yes,
-\v 12 they abandoned Me and neglected My law. And
+they abandoned Me and neglected My law.
+\v 12 And
 your own behaviour has been worse than that of your
 fathers. See how every man of you is following the
 impulses of his own wicked and stubborn heart and
-\v 13 refusing to listen to Me. For this, then, I will hurl you
+refusing to listen to Me.
+\v 13 For this, then, I will hurl you
 out of this land into a land that is strange to you and
 your fathers; and there, day and night, ye shall serve
 other gods; for no favour shall ye have from Me."
@@ -2391,10 +2446,12 @@ other gods; for no favour shall ye have from Me."
 \p
 \v 19 Jehovah commanded me to go and take my stand at
 the Benjamin gate, through which the kings of Judah
-\v 20 go in and out, and at all the gates of Jerusalem, and
+go in and out, and at all the gates of Jerusalem,
+\v 20 and
 there He charged me to address them as follows: "Ye
 kings of Judah, and all ye citizens of Judah and
-\v 21 Jerusalem that pass through these gates, Thus saith
+Jerusalem that pass through these gates,
+\v 21 Thus saith
 Jehovah: As ye value you lives, be very careful not
 to carry a burden or to bring anything of the kind
 through the gates of Jerusalem on the Sabbath day;
@@ -2407,7 +2464,8 @@ stiffened their neck; they would have nothing to
 will give earnest heed to Me, saith Jehovah, and
 refrain from bringing loads through the city gates on the
 Sabbath day, if you keep the Sabbath day holy and
-\v 25 abstain from work of every kind, then kings that
+abstain from work of every kind,
+\v 25 then kings that
 sit upon the throne of David shall enter the gates of
 this city riding on chariots and horses, accompanied
 by their princes, the men of Judah, and the citizens of
@@ -2416,7 +2474,8 @@ Jerusalem; and the city shall be inhabited for ever.
 Jerusalem, and the district of Benjamin, from the lowland,
 the hill country, and the south, men shall come
 to the Temple with burnt-offerings and sacrifices,
-\v 27 oblations and frankincense, and praise-offerings. If,
+oblations and frankincense, and praise-offerings.
+\v 27 If,
 however, you refuse to give heed to Me and to keep the
 Sabbath day holy by refraining from carrying burdens
 through the gates of Jerusalem on the Sabbath day,
@@ -2433,25 +2492,30 @@ shall devour the palaces of Jerusalem.
 
 \p
 \v 1 Jeremiah received from Jehovah the message which
-\v 2 follows: "Rise and go down to the potter's house–
+follows:
+\v 2 "Rise and go down to the potter's house–
 I have somewhat to say to thee, which I will
 communicate to thee there."
 \v 3 So I went down to the
 potter's house: and there he was – engaged on a
-\v 4 piece of work at the wheel. Now, if the thing he was
+piece of work at the wheel.
+\v 4 Now, if the thing he was
 making was spoiled in his hands, he would just shape
 the material over again into another such vessel as he
 had decided to make.
 \p
 \v 5 Thereupon there flashed upon me this message from
-\v 6 Jehovah. "Cannot I," He said, "deal with you,
+Jehovah.
+\v 6 "Cannot I," He said, "deal with you,
 O household of Israel, like this potter? You are
 in My hand just like the clay in the potter's hand.
 \v 7 At one moment I may decide to pluck up or break
-\v 8 down and destroy some nation of kingdom; but
+down and destroy some nation of kingdom;
+\v 8 but
 if the nation whose fate I have decreed turn from its
 wickedness, then I relent and do not execute the doom
-\v 9 I had planned for it. At another moment I may
+I had planned for it.
+\v 9 At another moment I may
 decide to build up or to plant some nation of kingdom;
 \v 10 but if its behaviour displeases Me, if it refuses to listen
 to My voice, then I will retract the favours I had
@@ -2462,7 +2526,8 @@ of Judah and the citizens of Jerusalem, Thus saith
 Jehovah: Beware! I am shaping calamity for you, I
 am fashioning plans for your discomfiture. Turn, then,
 every man of you, from your evil ways, and amend your
-\v 12 life and behaviour." But they will say, "No, there
+life and behaviour."
+\v 12 But they will say, "No, there
 is no hope of that: rather will we follow devices of our
 own and yield, every man of us, to the impulses of our
 wicked and stubborn hearts."
@@ -2551,23 +2616,28 @@ wicked and stubborn hearts."
 \p
 \v 1 Then Jehovah commanded me to go and buy a
 potter's earthenware flask, and, accompanied by a few
-\v 2 elders of the people and a few priests, to proceed
+elders of the people and a few priests,
+\v 2 to proceed
 to the Valley of the son of Hinnom by the entry of the
 Potsherd gate, and there announce the message with
-\v 3 which He would charge me. And the message was
+which He would charge me.
+\v 3 And the message was
 this: "Listen, ye kings of Judah, and ye citizens of
 Jerusalem, to what Jehovah is about to say: Thus
 saith Jehovah of Hosts, the God of Israel: Mark
 this well. I will soon bring such a catastrophe upon
 this place as will make the ears of all who hear of it
-\v 4 tingle; because they have forsaken Me and
+tingle;
+\v 4 because they have forsaken Me and
 denationalised this place by their burnt-offerings to other
 gods, strange alike to them and their forefathers;
 and the kings of Judah have filled this place with the
-\v 5 blood of innocent men. They have built Baal
+blood of innocent men.
+\v 5 They have built Baal
 sanctuaries to burn their sons in the fire as offerings to
 Baal, though this was no commandment of Mine – such
-\v 6 a thing never entered into My mind. Mark this,
+a thing never entered into My mind.
+\v 6 Mark this,
 therefore: days are coming, saith Jehovah, when this
 place shall be no more called Topheth, nor the Valley
 of the son of Hinnom, but the Valley of Slaughter;
@@ -2585,12 +2655,14 @@ be reduced by their enemies and by those that seek
 their life, they will devour one another.
 \p
 \v 10 Then thou shalt break the flask in the presence of
-\v 11 the men that accompany thee, and thou shalt say to
+the men that accompany thee,
+\v 11 and thou shalt say to
 them, Thus saith Jehovah of Hosts: This is how I will
 shatter this people and this city, just as a potter's
 jar is shattered beyond all possibility of repair; and
 Topheth shall be used as a burying-place for want of
-\v 12 room (elsewhere). This is how I will deal, saith
+room (elsewhere).
+\v 12 This is how I will deal, saith
 Jehovah, with this place and its inhabitants – I will
 \v 13 make this city like Topheth; and the houses of
 Jerusalem and of the kings of Judah shall be, like the
@@ -2608,7 +2680,8 @@ poured out to other gods.
 \v 14 Then Jeremiah returned from Topheth to which
 Jehovah had sent him on his prophetic errand; and,
 taking his stand in the Temple court he thus addressed
-\v 15 the assembled people: "Thus saith Jehovah of Hosts,
+the assembled people:
+\v 15 "Thus saith Jehovah of Hosts,
 the God of Israel, Mark this well; soon I will bring
 upon this city and upon all her villages the full measure
 of disaster with which I have threatened her, because
@@ -2622,22 +2695,27 @@ to My words."
 \p
 \v 1 Now when Pashhur, the son of Immer the priest,
 who had the general supervision of the Temple, heard
-\v 2 this prophetic utterance of Jeremiah's, he beat him
+this prophetic utterance of Jeremiah's,
+\v 2 he beat him
 and put him in the stocks that were at the upper
-\v 3 Benjamin gate in the Temple. Next day, after
+Benjamin gate in the Temple.
+\v 3 Next day, after
 Pashhur had released Jeremiah from the stocks,
 Jeremiah said to him, "Thy name is (henceforth)
-\v 4 changed from Pashhur to Terror. For thus saith
+changed from Pashhur to Terror.
+\v 4 For thus saith
 Jehovah: See! I will make thee a terror to thyself
 and to all thy friends. They shall fall by the enemy's
 sword, and thou shalt see it with thine own eyes. I
 will give the whole of Judah into the hands of the
 king of Babylon, and he shall carry them to exile in
-\v 5 Babylon and slay them with the sword. And all the
+Babylon and slay them with the sword.
+\v 5 And all the
 resources of this city, all her wealth, all that she prizes,
 all the treasures of the kings of Judah, I will deliver
 into the hands of their enemies, who shall despoil them
-\v 6 and carry them off to Babylon. As for thee, Pashhur,
+and carry them off to Babylon.
+\v 6 As for thee, Pashhur,
 thou and all who share thy home shall be swept into
 captivity. To Babylon thou shalt come; there
 thou shalt die, and there shalt thou be buried – thou
@@ -2733,23 +2811,26 @@ and all the friends to whom thou hast prophesied lies."
 \v 1 The message which came to Jeremiah from Jehovah,
 when King Zedekiah sent the following request to him
 through Pashhur, the son of Malchiah and Zephaniah,
-\v 2 the son of Maaseiah the priest. "Be good enough," they
+the son of Maaseiah the priest.
+\v 2 "Be good enough," they
 said, "to enquire of Jehovah on our behalf: for
 Nebuchadrezzar, the king of Babylon is fighting against
 us. Perhaps Jehovah will so deal with us in His own
 wonderful way that the siege will be raised."
 \p
 \v 3 To the deputation Jeremiah replied: "Take this
-\v 4 answer back to Zedekiah. Thus saith Jehovah, the
+answer back to Zedekiah.
+\v 4 Thus saith Jehovah, the
 God of Israel: Now you are able to fight outside the
 wall with the king of Babylon and the Chaldeans who
 are besieging you; but soon I will drive you with the
-\v 5 weapons you handle inside this city. And I myself
+weapons you handle inside this city.
+\v 5 And I myself
 will fight against you with outstretched hand and
 mighty arm – in anger, in fury, and in towering wrath.
 \v 6 Yes, I will smite the inhabitants of this city, both man
-\v 7 and beast, with a great and deadly pestilence.
-Thereafter, saith Jehovah, Zedekiah, king of Judah and his
+and beast, with a great and deadly pestilence.
+\v 7 Thereafter, saith Jehovah, Zedekiah, king of Judah and his
 ministers and the people in this city that survive the
 pestilence, sword and famine, I will deliver into the
 hands of Nebuchadrezzar, king of Babylon, and into
@@ -2760,11 +2841,13 @@ pity.
 \p
 \v 8 To the people thy message shall be this. Thus saith
 Jehovah: See! I set before you the way of life and the
-\v 9 way of death. Whoever remains in this city shall die
+way of death.
+\v 9 Whoever remains in this city shall die
 by sword, famine, or pestilence; but whoever goes out
 and surrenders to the Chaldeans that besiege you shall
 be spared, though he shall escape with nothing but
-\v 10 his life. For, saith Jehovah, I have set My face against
+his life.
+\v 10 For, saith Jehovah, I have set My face against
 this city for evil and not for good; into the hands of the
 king of Babylon it shall be given, and he shall burn it
 with fire.
@@ -2806,7 +2889,8 @@ In the morning give righteous judgment,
 \p
 \v 1 Jehovah commanded me to go down to the palace
 of the king of Judah and there deliver the following
-\v 2 message: O king of Judah that sittest on the throne of
+message:
+\v 2 O king of Judah that sittest on the throne of
 David, listen to the word of Jehovah – thou and thy
 ministers and thy people who enter these gates.
 \v 3 Thus saith Jehovah: Conduct your administration on
@@ -2814,10 +2898,12 @@ principles of justice and right, deliver the victims
 of exploitation from the clutch of the oppressor, refrain
 from all wrong and violence to the resident foreigner, the
 fatherless and the widow, and shed no innocent blood
-\v 4 in this place. If you carry out this policy faithfully,
+in this place.
+\v 4 If you carry out this policy faithfully,
 then kings upon the throne of David shall pass through
 the gates of this house, riding in chariots and on horses
-\v 5 –they, their ministers and their people. But if you
+–they, their ministers and their people.
+\v 5 But if you
 ignore this message (of Mine), then, saith Jehovah, I
 solemnly swear that this house shall be laid in ruins.
 \p
@@ -2835,7 +2921,8 @@ Though thou art to Me as Gilead,
 \p
 \v 8 The people of many nations, as they pass by this city,
 shall ask one another why Jehovah has dealt thus with
-\v 9 this great city, and they shall answer: It is because
+this great city,
+\v 9 and they shall answer: It is because
 they abandoned their covenant with Jehovah their
 God and gave themselves up to the worship and service
 of other gods.
@@ -2853,7 +2940,8 @@ of other gods.
 \v 11 For this is the word of Jehovah concerning Shallum,
 the son of Josiah, king of Judah, the successor of his
 father Josiah, who went forth from this place: "He
-\v 12 shall never come back to it again; but in the land of
+shall never come back to it again;
+\v 12 but in the land of
 exile to which they have carried him he shall die, and
 this land he shall see no more."
 
@@ -2924,10 +3012,12 @@ on thy right hand, yet I would tear him off.
 \v 25 Yea, I will deliver thee into the hands of those that
 seek thy life, and into the hands of those thou dreadest,
 into the hands of Nebuchadrezzar, king of Babylon,
-\v 26 and into the hands of the Chaldeans. Yea, thee and
+and into the hands of the Chaldeans.
+\v 26 Yea, thee and
 the mother that bore thee I will hurl into another land
 than the land thou wast born in, and there thou shalt
-\v 27 die. Nevermore shall they return to the land to which
+die.
+\v 27 Nevermore shall they return to the land to which
 they long to return.
 \v 28 Hath this man Coniah become
 \q2 Like a figure one smasheth in scorn,
@@ -3107,7 +3197,8 @@ and they shall dwell in their own land.
 \v 30 Mark this, therefore, saith Jehovah, I am against
 the prophets that steal My words from one another.
 \v 31 I am against the prophets who take their tongues
-\v 32 and immediately reel off an oracle. I am against the
+and immediately reel off an oracle.
+\v 32 I am against the
 prophets that prophesy living dreams, seducing My
 people by their lies and their windy boasts. They have
 not been sent by Me, nor have they any commission
@@ -3124,19 +3215,23 @@ what is the burden of Jehovah, tell them, "You"
 saith Jehovah, "are the burden, and I will cast you off.
 \v 34 As for the prophet, the priest, or the layman, who
 speaks any more of Jehovah's 'burden,', that man and
-\v 35 his household I will visit with judgment. You must
+his household I will visit with judgment.
+\v 35 You must
 say to one another, 'What is Jehovah's answer?' or
-\v 36 'What is Jehovah's message?' But you are not to
+'What is Jehovah's message?'
+\v 36 But you are not to
 make mention to the burden of Jehovah any more.
 Every man's own (uninspired) word shall be his
 burden; for you have perverted the words of the
-\v 38 living God, Jehovah of Hosts, our God. If, however,
+living God, Jehovah of Hosts, our God.
+\v 38 If, however,
 you persist in speaking of 'the burden of Jehovah,'
 Jehovah pronounces this word of doom: Because you
 persist in using this expression 'burden of Jehovah,'
 despite My explicit command to you not to use it,
 \v 39 I will lift you up and cast you out of My sight – you
-\v 40 and the city I gave to you and your fathers, and I
+and the city I gave to you and your fathers,
+\v 40 and I
 will lay upon you everlasting reproach and unending
 disgrace which shall never be forgotten."
 
@@ -3154,7 +3249,8 @@ with the princes, the craftsmen and the smiths, had been
 carried from Jerusalem by Nebuchadrezzar, king of
 Babylon, into exile in Babylon, Jehovah in a vision
 showed me two baskets of figs set down in front of
-\v 2 Jehovah's Temple. One basket contained excellent
+Jehovah's Temple.
+\v 2 One basket contained excellent
 figs, like the figs that are first ripe: the figs in the other
 were very bad, so bad that they could not be eaten."
 \p
@@ -3168,10 +3264,12 @@ eaten."
 \v 5 "Thus saith Jehovah the God of Israel: As with these
 good figs, so will I regard with favour the exiles of
 Judah, whom I have sent out of this place into the land
-\v 6 of the Chaldeans. I will set Mine eyes upon them for
+of the Chaldeans.
+\v 6 I will set Mine eyes upon them for
 good, and bring them back to this land. I will not pull
 them down, but I will build them; I will not pluck them
-up, but I will plant them; and I will give them a heart
+up, but I will plant them;
+\v 7 and I will give them a heart
 to understand me, that I am Jehovah. They shall be
 My people and I will be their God, if they turn to Me
 with all their heart.
@@ -3180,7 +3278,8 @@ with all their heart.
 Jehovah: They are symbolic of the fate of Zedekiah,
 king of Judah, and his princes, and the survivors of
 Jerusalem that are left in this land, and those whose
-\v 9 home is in the land of Egypt. For I will make them
+home is in the land of Egypt.
+\v 9 For I will make them
 an object of consternation among every kingdom in
 the world, a reproach and a proverb, a taunt and a
 curse, in every place to which I shall drive them;
@@ -3204,7 +3303,8 @@ upon Judah, upon the Neighbouring Nations, and upon the World at Large
 \v 1 The message which came to Jeremiah concerning all
 the people of Judah in the fourth year of Jehoiakim,
 the son of Josiah, king of Judah, which was the first
-\v 2 year of Nebuchadrezzar, king of Babylon – the message
+year of Nebuchadrezzar, king of Babylon –
+\v 2 the message
 he delivered to all the people of Judah and all
 the citizens of Jerusalem:
 \p
@@ -3215,7 +3315,8 @@ and I have declared it to you early and late, but you
 \v 4 have not listened. And early and late Jehovah has
 been sending to you all His servants the prophets,
 through you have not listened nor inclined an attentive
-\v 5 ear. My message was this: "If you abandon, every
+ear.
+\v 5 My message was this: "If you abandon, every
 man of you, your wicked ways and your evil behaviour,
 then you shall dwell for ever in the land which Jehovah,
 gave in the ancient time to you and your forefathers.
@@ -3230,12 +3331,14 @@ of your own hands: this can only injure yourselves."
 
 \p
 \v 8 Therefore thus saith Jehovah of Hosts: Because
-\v 9 ye have not listened to My words, I will send and
+ye have not listened to My words,
+\v 9 I will send and
 fetch a clan from the north, and I will bring them
 against this land and its inhabitants and against the
 surrounding nation. I will devote them to destruction
 so appalling that men shall hiss and revile them
-\v 10 for ever; and I will banish from them the voice of mirth
+for ever;
+\v 10 and I will banish from them the voice of mirth
 and gladness, the voice of bridegroom and bride, the
 sound of the millstones and the light of the lamp.
 \v 11 This whole land shall be a waste and a horror, and
@@ -3245,7 +3348,8 @@ years.
 \v 12 When, however, seventy years are completed, I will punish
 the king of Babylon, and that nation, saith Jehovah, for their
 guilt, and also the land of the Chaldeans, which I will make
-\v 13 desolate for ever; and I will bring upon that land all the words
+desolate for ever;
+\v 13 and I will bring upon that land all the words
 I have pronounced against it – everything prophesied by
 Jeremiah against all the nations, that is recorded in this Book.
 \v 14 They, yes they, shall be reduced to slavery at the hands of
@@ -3261,20 +3365,26 @@ that their acts and deeds deserve.
 "Take from My hand this wine-cup of wrath, and give
 it to all the nations to whom I send thee to drink from;
 \v 16 and let them drink and reel in madness because of the
-\v 17 sword that I will send among them." So I took the
+sword that I will send among them."
+\v 17 So I took the
 cup from the hand of Jehovah, and I gave it to all the
 nations to whom Jehovah had sent me, to drink from–
 \v 18 Jerusalem and the cities of Judah, with her kings and
 princes, to be made a desolation, a horror, a scorn,
-\v 19 and a curse; Pharaoh, king of Egypt, with his
-\v 20 ministers, his princes, and all his people, and all
+and a curse;
+\v 19 Pharaoh, king of Egypt, with his
+ministers, his princes, and all his people,
+\v 20 and all
 the foreign folk; all the kings of the land of Uz, and
 all the kings of the land of the Philistines – Ashkelon,
-\v 21 Gaza, Ekron, and the survivors of Ashdod; Edom,
-\v 22 Moab, and Ammon; all the kings of Tyre and Sidon;
+Gaza, Ekron, and the survivors of Ashdod;
+\v 21 Edom,
+Moab, and Ammon;
+\v 22 all the kings of Tyre and Sidon;
 and the kings of the coast-land across the sea;
 \v 23 Dedan and Tema and Buz, and all those that have the
-\v 24 corners of their hair clipped; all the kings of Northern
+corners of their hair clipped;
+\v 24 all the kings of Northern
 Arabia, and all the kings of the north, far and near,
 one with another, and all the kingdoms on the face of
 the earth; and after them shall the king of Sheshach
@@ -3283,9 +3393,11 @@ drink.
 \v 27 Thou shalt say to them, Thus saith Jehovah of Hosts,
 the God of Israel: Drink yourselves drunk till ye fall in
 your vomit, to rise no more, because of the sword that I
-\v 28 shall send among you. If they refuse to take the cup from
+shall send among you.
+\v 28 If they refuse to take the cup from
 thy hand to drink, then thou shalt say to them, Thus saith
-\v 29 Jehovah of Hosts: Drink it you shall; for, if the city
+Jehovah of Hosts: Drink it you shall;
+\v 29 for, if the city
 which is called by Mine own name is the first to feel the
 weight of My displeasure, how can you expect to go
 utterly unpunished? Nay, verily, ye shall not escape;
@@ -3346,30 +3458,37 @@ Jehovah will roar from on high,
 \p
 \v 1 In the beginning of the reign of Jehoiakim, the son of
 Josiah, king of Judah, the message which follows came
-\v 2 (to Jeremiah) from Jehovah: Thus saith Jehovah,
+(to Jeremiah) from Jehovah:
+\v 2 Thus saith Jehovah,
 Take thy stand in the Temple court, and declare without
 reservation to all the people of Judah who are come
 to worship in the Temple, the whole message that I
-\v 3 have commissioned thee to declare. It may be that
+have commissioned thee to declare.
+\v 3 It may be that
 they will listen and severally abandon their wicked
 ways: if they do, I will relent and not bring upon them
 the calamity I am planning as penalty for their evil
-\v 4 behaviour. This, then, is what thou art to say to
+behaviour.
+\v 4 This, then, is what thou art to say to
 them, Thus saith Jehovah: If ye refuse to obey Me–
 to live in accordance with the law that I have set before
-\v 5 you, and to listen, as ye have never yet listened, to the
+you,
+\v 5 and to listen, as ye have never yet listened, to the
 words of My servants the prophets, whom early and
-\v 6 late I have been sending to you – then I will make this
+late I have been sending to you –
+\v 6 then I will make this
 Temple like Shiloh, and as for this city, I will turn it
 into an object of execration to every nation in the world.
 \p
 \v 7 Now the audience that listened to this message of
 Jeremiah's in the Temple included not only the whole
 body of the people, but the priests and the prophets
-\v 8 as well. So when he had concluded the message which
+as well.
+\v 8 So when he had concluded the message which
 Jehovah had commissioned him to declare to the whole
-\v 9 people, the priests and the prophets seized him. "You
-must die," they exclaimed; "for how dare you
+people, the priests and the prophets seized him. "You
+must die," they exclaimed;
+\v 9 "for how dare you
 deliver in the name of Jehovah such a message as this,
 that this Temple will meet the fate of Shiloh, and that
 this city shall become an inhabited desolation?"
@@ -3384,16 +3503,19 @@ their seats at the entrance to the new gate of the Temple,
 the countries and the whole body of the people. "This
 man." they said, "is guilty of a capital offence; for
 he has solemnly declared that this city is doomed–
-\v 12 you have heard him with your own ears. Then
+you have heard him with your own ears.
+\v 12 Then
 Jeremiah in his turn addressed himself to the courtiers
 and to the whole body of the people. "It is Jehovah
 Himself," he said, "that has sent me to proclaim upon
 this Temple and city the doom which you have just
-\v 13 heard. If, however, you amend your life and conduct,
+heard.
+\v 13 If, however, you amend your life and conduct,
 and listen to the voice of Jehovah your God, then
 He will relent and cancel His threat of catastrophe.
 \v 14 As for myself, I am in your hands: deal with me as
-\v 15 you think right and proper. But be very sure of this,
+you think right and proper.
+\v 15 But be very sure of this,
 that, if you put me to death, you will only be bringing
 innocent blood upon yourselves, upon this city, and
 upon her people; for it is the simple truth that Jehovah
@@ -3404,7 +3526,8 @@ any capital offence; for his message to us has behind
 it the authority of Jehovah our God."
 \p
 \v 17 Them some of the elders, rising to their feet, thus
-\v 18 addressed the people assembled: "In the days of Hezekiah,
+addressed the people assembled:
+\v 18 "In the days of Hezekiah,
 king of Judah," they said, "Micah of Moresheth was
 prophesying; and this is what he said to all the people
 of Judah:
@@ -3429,14 +3552,17 @@ on the verge of involving ourselves in a great calamity."
 prophetic messages in the name of Jehovah – Uriah,
 the son of Shemaiah, who belonged to Kiriath-jearim.
 Quite in the manner of Jeremiah, he too had pronounced
-\v 21 the doom of this city and land. His message having
+the doom of this city and land.
+\v 21 His message having
 reached the ears of King Jehoiakim, with all the court
 and the military officials, the king took steps to have
 him put to death. Urijah, however, got wind of his
 purpose, and in terror he took to flight, finally reaching
-\v 22 Egypt; but King Jehoiakim despatched commissioners
+Egypt;
+\v 22 but King Jehoiakim despatched commissioners
 to Egypt – Elnathan the son of Achbor, and a few
-\v 23 others – who removed him from Egypt and brought
+others –
+\v 23 who removed him from Egypt and brought
 him back to the presence of King Jehoiakim, who
 had him slain with the sword, and his dead body flung
 into the public burying-ground.
@@ -3459,17 +3585,22 @@ to the people for execution.
 \p
 \v 1 In the beginning of the reign of Zedekiah, the son
 of Josiah, king of Judah, Jeremiah received from
-\v 2 Jehovah the message which follows. Thus spoke
+Jehovah the message which follows.
+\v 2 Thus spoke
 Jehovah: Make thongs and bars and put them on
-\v 3 thy neck, and send a message to the kings of Edom,
+thy neck,
+\v 3 and send a message to the kings of Edom,
 Moab, Ammon, Tyre, and Sidon, through their ambassadors
 who have come to Jerusalem to Zedekiah,
-\v 4 king of Judah, and bid them say to their masters,
+king of Judah,
+\v 4 and bid them say to their masters,
 "Thus saith Jehovah of Hosts, the God of Israel:
-\v 5 Convey this message to your masters. I have made
+Convey this message to your masters.
+\v 5 I have made
 the earth, with man and beast on the face of it,
 by My great power and outstretched arm, and I give it
-\v 6 to whomsoever I please. At the moment I have given
+to whomsoever I please.
+\v 6 At the moment I have given
 all these lands into the hands of Nebuchadnezzar, king
 of Babylon, My servant; the beasts of the field also
 have I given him to serve him.
@@ -3487,9 +3618,11 @@ pestilence, till I have delivered them into his hands.
 \v 9 As for yourselves, do not listen to your prophets,
 diviners, dreamers, soothsayers, or sorcerers, who
 assure you that you will not be subject to the king of
-\v 10 Babylon. It is a lie that they preach to you, and it
+Babylon.
+\v 10 It is a lie that they preach to you, and it
 will end in your removal from your own land; for I
-\v 11 will indeed drive you away and ye shall perish. But
+will indeed drive you away and ye shall perish.
+\v 11 But
 the nation that brings its neck to the yoke of the king of
 Babylon and serves him, I will leave on their own soil,
 which they shall continue to till and occupy."
@@ -3497,10 +3630,12 @@ which they shall continue to till and occupy."
 \v 12 A similar message I gave to Zedekiah, king of Judah,
 "If," said I, "you bring your neck to the yoke of the
 king of Babylon, and serve him and his people, you will
-\v 13 be spared. Why should you and your people die by the
+be spared.
+\v 13 Why should you and your people die by the
 sword, famine and pestilence, with which Jehovah has
 threatened the nation that refuses to serve the king of
-\v 14 Babylon? Do not listen to the prophets when they tell
+Babylon?
+\v 14 Do not listen to the prophets when they tell
 you that you will not be subject to the king of Babylon:
 \v 15 they are preaching to you a lie. I have not sent them,
 saith Jehovah: it is a lie that they are preaching to you
@@ -3514,20 +3649,25 @@ listen to the prophets when they tell you that the vessels
 of the Temple will soon be brought back from Babylon.
 \v 17 They are preaching to you a lie: do not listen to them.
 Serve the king of Babylon and you will be spared:
-\v 18 why should this city become a ruin? But if they are
+why should this city become a ruin?
+\v 18 But if they are
 real prophets with a real message from Jehovah, let
 them entreat Jehovah of Hosts not to allow the vessels
 that are left in the Temple and in the royal palace at
-\v 19 Jerusalem, to be taken to Babylon. For thus saith
+Jerusalem, to be taken to Babylon.
+\v 19 For thus saith
 Jehovah of Hosts concerning the pillars and the sea
 and the stands and the rest of the vessels that are left
-\v 20 in this city, which were not taken by Nebuchadnezzar,
+in this city,
+\v 20 which were not taken by Nebuchadnezzar,
 king of Babylon, when he carried Jeconiah, the son of
 Jehoiakim, king of Judah, with all the nobles of Judah
-\v 21 and Jerusalem, from Jerusalem to Babylon. Yes,
+and Jerusalem, from Jerusalem to Babylon.
+\v 21 Yes,
 thus saith Jehovah of Hosts, the God of Israel, concerning
 the vessels that are left in the Temple and in
-\v 22 the royal palace and at Jerusalem; To Babylon
+the royal palace and at Jerusalem;
+\v 22 To Babylon
 they shall be brought, and there they shall remain till
 the day that I visit them, saith Jehovah; then I will
 bring them up and restore them to this place."
@@ -3546,7 +3686,8 @@ Zedekiah, king of Judah, in the fifth month of the fourth
 year, Hananiah the son of Azzur, the prophet, who
 belonged to Gibeon, addressed me as follows in the
 Temple in the presence of the priests and of all the
-\v 2 people. "Thus saith Jehovah of Hosts, the God of
+people.
+\v 2 "Thus saith Jehovah of Hosts, the God of
 Israel: 'I have broken the yoke of the king of Babylon.
 \v 3 Within two years' time I will bring back to this place all
 the Temple vessels that Nebuchadnezzar, king of
@@ -3558,19 +3699,24 @@ break the yoke of the king of Babylon.'"
 \p
 \v 5 Then Jeremiah the prophet replied to Hananiah the
 prophet in the presence of the priests and of all the
-people that were standing in the Temple; and Jeremiah
-\v 6 the prophet said, "Amen! Jehovah do so! May
+people that were standing in the Temple;
+\v 6 and Jeremiah
+the prophet said, "Amen! Jehovah do so! May
 Johevah fulfil your prophecy and bring back the Temple
 vessels and all the exiles from Babylon to this place!
 \v 7 I ask you, however to listen to this word that I am
 about to speak in your hearing and in the hearing of all
-\v 8 the people. From the beginning the prophets who
+the people.
+\v 8 From the beginning the prophets who
 preceded you and me in their messages concerning many
-\v 9 lands and mighty kingdoms, prophesied war. If a
+lands and mighty kingdoms, prophesied war.
+\v 9 If a
 prophet prophesies peace, it is only when his word has
 been fulfilled that you can be sure that he has had a real
-\v 10 commission from Jehovah." Then Hananiah took the
-\v 11 bar off Jeremiah's neck, broke it, and declared in the
+commission from Jehovah."
+\v 10 Then Hananiah took the
+bar off Jeremiah's neck, broke it,
+\v 11 and declared in the
 presence of all the people, "Thus saith Jehovah:
 'Within two years' time, I will similarly break the
 yoke of Nebuchadnezzar, king of Babylon, off the
@@ -3579,20 +3725,25 @@ went away.
 \p
 \v 12 But after Hananiah had broken the bar off Jeremiah's
 neck, there came to Jeremiah this message from
-\v 13 Jehovah: "Go and say to Hananiah, Thus saith
+Jehovah:
+\v 13 "Go and say to Hananiah, Thus saith
 Jehovah, The wooden bar you have indeed broken,but
-\v 14 I will replace it with a bar of iron. For thus saith
+I will replace it with a bar of iron.
+\v 14 For thus saith
 Jehovah of Hosts, the God of Israel: The yoke that I
 will put on the necks of all these nations will be made
 of iron – a yoke of service to Nebuchadnezzar, king of
 Babylon: for serve him they shall. I have also given
-\v 15 him the beasts of the field." Then Jeremiah said to
+him the beasts of the field."
+\v 15 Then Jeremiah said to
 Hananiah, "Listen, Hananiah. You have no commission
-\v 16 from Jehovah: you are making this people
-trust a lie. Therefore thus saith Jehovah: 'Mark this
+from Jehovah: you are making this people
+trust a lie.
+\v 16 Therefore thus saith Jehovah: 'Mark this
 well: I will dismiss thee from the face of the earth.
 This very year thou shalt die; for thy words are a
-\v 17 disloyalty to Jehovah.'" And that very year, in the
+disloyalty to Jehovah.'"
+\v 17 And that very year, in the
 seventh month, the prophet Hananiah died.
 
 
@@ -3608,7 +3759,8 @@ seventh month, the prophet Hananiah died.
 Jerusalem by Jeremiah the prophet to the elders, the
 priests, the prophets, and all the people, who had been
 carried from Jerusalem by Nebuchadnezzar to exile in
-\v 2 Babylon – after the surrender of Jeconiah the king,
+Babylon –
+\v 2 after the surrender of Jeconiah the king,
 and the queen-mother, and the eunuchs, and the princes
 of Judah and Jerusalem, and the craftsmen and smiths–
 \v 3 the letter being sent by the hands of Eleasah the son of
@@ -3618,7 +3770,8 @@ Babylon, by Zedekiah, king of Judah:
 \p
 \v 4 "Thus saith Jehovah of Hosts, the God of Israel, to
 all the exiles whom I have carried from Jerusalem to
-\v 5 Babylon: Build houses and settle; plant gardens
+Babylon:
+\v 5 Build houses and settle; plant gardens
 and eat the fruit of them; take wives and rear families;
 \v 6 take wives also for your sons and give your daughters
 to husbands, that they may have sons and daughters;
@@ -3636,12 +3789,16 @@ Jehovah.
 \v 10 For thus saith Jehovah: As soon as Babylon's
 seventy years are accomplished, I will visit you and
 bring you back to this place, in fulfilment of the gracious
-\v 11 promise I made you. For I know the thoughts I cherish
+promise I made you.
+\v 11 For I know the thoughts I cherish
 towards you – thoughts of weal and not of woe – to
-\v 12 bestow upon you a future and a hope. When you
+bestow upon you a future and a hope.
+\v 12 When you
 call, I will answer you, and I will listen to your
-\v 13 prayer. If ye seek Me ye shall find Me. If ye seek
-\v 14 Me with all your heart, I will reveal Myself to you,
+prayer.
+\v 13 If ye seek Me ye shall find Me. If ye seek
+Me with all your heart,
+\v 14 I will reveal Myself to you,
 saith Jehovah; and I will restore your fortunes and gather you
 from all the nations and places to which I have driven you,
 saith Jehovah, and I will bring you back to the place from
@@ -3651,28 +3808,34 @@ which I carried you into exile.
 \v 16 For thus saith Jehovah concerning the king who sits on
 the throne of David, and concerning all the people whose home
 is in this city – those brethren of yours who have not had to
-\v 17 accompany you into exile. Thus saith Jehovah of Hosts: See! I
+accompany you into exile.
+\v 17 Thus saith Jehovah of Hosts: See! I
 will send the sword, the famine and the pestilence among them,
 and I will make them like figs that are too horribly bad to eat.
 \v 18 I will hunt them with sword, famine, and pestilence and I will
 make them an object of consternation to every kingdom in the
 world, and object of execration and horror, of scorn and insult
-\v 19 among all the nations to which I have driven them; because,
+among all the nations to which I have driven them;
+\v 19 because,
 saith Jehovah, they refused to listen to the messages I sent them
 early and late through My servants the prophets – yes, they
-\v 20 refused to listen, saith Jehovah. See, then, that ye listen to
+refused to listen, saith Jehovah.
+\v 20 See, then, that ye listen to
 Jehovah's message, all of you exiles whom I have sent from
 Jerusalem to Babylon.
-\v 21 in Babylon. Well, thus saith Jehovah of Hosts, the
+in Babylon.
+\v 21 Well, thus saith Jehovah of Hosts, the
 God of Israel, concerning Ahab the son of Kolaiah and
 Zedekiah the son of Maaseiah, who preach to you a lie
 in My name. Mark this: I will deliver them into the
 hands of Nebuchadrezzar, king of Babylon, and he
-\v 22 will slay them before your eyes; and their fate shall be
+will slay them before your eyes;
+\v 22 and their fate shall be
 adopted by all the exiles of Judah in Babylon as a
 model for imprecation. "Jehovah make thee," they
 will say, "like Zedekiah and Ahab, whom the king of
-\v 23 Babylon roasted in the fire," because they wrought
+Babylon roasted in the fire,"
+\v 23 because they wrought
 impious folly in Israel, in committing adultery with
 their neighbours' wives and delivering in My name
 lying messages which I never gave them. Well I
@@ -3680,15 +3843,19 @@ know it, saith Jehovah, and I am witness."
 \p
 \v 24 Touching the message of Jehovah of Hosts, the
 God of Israel, to be delivered by Jeremiah concerning
-\v 25 Shemaiah of Nehelam. This is the man who sent a
+Shemaiah of Nehelam.
+\v 25 This is the man who sent a
 letter in his own name to Zephaniah, the son of
-\v 26 Maaseiah the priest. "Jehovah," he wrote, "has
+Maaseiah the priest.
+\v 26 "Jehovah," he wrote, "has
 made you priest in the place of Jehoiada the priest,
 to exercise an oversight in the Temple over all that play
 the mad prophet and the ecstatic, and to put all such
-\v 27 in the stocks and in the iron collar. Why then did you
+in the stocks and in the iron collar.
+\v 27 Why then did you
 not rebuke Jeremiah of Anathoth, who has been playing
-\v 28 the mad prophet among you? For he has sent a
+the mad prophet among you?
+\v 28 For he has sent a
 message to us in Babylon, maintaining that the exile
 would be long, and urging us to build houses and settle,
 and to plant gardens and eat the fruit of them."
@@ -3696,10 +3863,12 @@ and to plant gardens and eat the fruit of them."
 of Jeremiah the prophet.
 \p
 \v 30 Then there came to Jeremiah this message from
-\v 31 Jehovah: Send to all the exiles and say, Thus saith
+Jehovah:
+\v 31 Send to all the exiles and say, Thus saith
 Jehovah concerning Shemaiah of Nehelam: Shemaiah
 has been prophesying to you without any commission
-\v 32 from Me and has made you trust in a lie. For this
+from Me and has made you trust in a lie.
+\v 32 For this
 reason, therefore– thus saith Jehovah – I will punish
 Shemaiah of Nehelam and his descendants: not a
 man shall he have among you who will ever see the good
@@ -3730,7 +3899,8 @@ re-establish them in possession of the land I gave their
 forefathers.
 \p
 \v 4 Now these are the words Jehovah hath spoken
-\v 5 concerning Israel and Judah. Yea, thus saith Jehovah:
+concerning Israel and Judah.
+\v 5 Yea, thus saith Jehovah:
 \q We have heard a cry of terror,
 \q2 Of horror and dispeace.
 \q
@@ -4067,11 +4237,11 @@ forefathers.
 \p
 \v 38 Be assured, saith Jehovah, the days are coming, when
 the city shall again be built up for Jehovah from the
-\q
-\v 39 tower of Hananel to the gate at the corner, and the
+tower of Hananel to the gate at the corner,
+\v 39 and the
 line of the wall shall pass straight on to the hill Gareb,
-\q
-\v 40 where it will turn round to Goah. Further, the entire
+where it will turn round to Goah.
+\v 40 Further, the entire
 valley (of Hinnom) with its corpses and ashes and
 the whole locality as far as the valley of Kidron up
 to the corner of the horse-gate on the east, shall be
@@ -4094,10 +4264,12 @@ Family at Anathoth
 \p
 \v 1 The message which came to Jeremiah from Jehovah
 in the tenth year of Zedekiah, king of Judah, which
-\v 2 was in the eighteenth year of Nebuchadrezzar. At that
+was in the eighteenth year of Nebuchadrezzar.
+\v 2 At that
 time the forces of the king of Babylon were investing
 Jerusalem, and Jeremiah the prophet was confined to
-\v 3 the guard-house of the royal palace, where Zedekiah the
+the guard-house of the royal palace,
+\v 3 where Zedekiah the
 king had shut him up on account of his prophetic
 preaching. "What do you mean," he had demanded,
 "by an announcement of this kind: 'Thus saith
@@ -4106,38 +4278,46 @@ hands of the king of Babylon, and he shall take it.
 \v 4 Nor shall Zedekiah, king of Judah, escape the hands of
 the Chaldeans; he will assuredly be delivered into the
 hands of the king of Babylon. He shall speak to him
-\v 5 face to face, and see him eye to eye; and he shall bring
+face to face, and see him eye to eye;
+\v 5 and he shall bring
 Zedekiah to Babylon, where he will remain till I visit
 him. Though you fight with the Chaldeans you shall
 have no success.'"
 \p
 \v 6 Now there came to Jeremiah the following message
-\v 7 from Jehovah: "Hanamel, the son of thine uncle
+from Jehovah:
+\v 7 "Hanamel, the son of thine uncle
 Shallum, is about to pay thee a visit, to request thee to
 buy the land he holds at Anathoth; and he will urge
 that, as thou art the next of kin, it is thy privilege and
-\v 8 duty to receive it." And so it happened: my cousin
+duty to receive it."
+\v 8 And so it happened: my cousin
 Hanamel paid me in the guard-house the visit Jehovah
 had intimated, and said: "I want you to buy the land
 I possess at Anathoth; for you are the legal heir, and
 it is your duty to secure it – so buy it for yourself."
 Then I recognised that the message I had received was
-\v 9 really from Jehovah. So I bought the land at Anathoth
+really from Jehovah.
+\v 9 So I bought the land at Anathoth
 from my cousin Hanamel, and I weighed out the money
-\v 10 to him – seventeen silver shekels. Then I signed the
+to him – seventeen silver shekels.
+\v 10 Then I signed the
 deed and sealed it, took witnesses, and paid him the
-\v 11 money in full. I then took the purchase-deed–
+money in full.
+\v 11 I then took the purchase-deed–
 the one which was sealed and the one which was open–
 \v 12 and gave it to Baruch, the son of Neriah, the son of
 Machesiah, in the presence of my cousin Hanamel, and
 of the witnesses who had signed the purchase-deed
-\v 13 and of all the Jews in the guard-house. In their
+and of all the Jews in the guard-house.
+\v 13 In their
 presence I then gave these instructions to Baruch:
 \v 14 "Thus saith Jehovah of Hosts, the God of Israel:
 Take these deeds – this purchase deed which is sealed
 and this deed which is open – and put them in an
 earthenware jar, so that they may be preserved for a
-\v 15 long time to come. For thus saith Jehovah of Hosts,
+long time to come.
+\v 15 For thus saith Jehovah of Hosts,
 the God of Israel: A time is coming when houses and
 fields and vineyards shall again be bought in this land."
 
@@ -4150,22 +4330,26 @@ fields and vineyards shall again be bought in this land."
 the son of Neriah, I prayed in these words to Jehovah:
 \v 17 "Ah, Lord Jehovah! Thou, by Thy mighty power and
 outstretched arm, hast made the heavens and the earth,
-\v 18 and nothing is too hard for Thee. Kindness Thou
+and nothing is too hard for Thee.
+\v 18 Kindness Thou
 showest to thousands, and retribution for the guilt of
 the fathers thou bringest home to their children after
-\v 19 them, Thou great and mighty God, great in purpose and
+them, Thou great and mighty God,
+\v 19 great in purpose and
 mighty in action, whose eyes are open to all the ways of
 men, giving to each his deserts and the fruit of his deeds.
 \v 20 In the land of Egypt Thou didst set in Israel and
 among (other) men signs and wonders (which are
 commemorated) unto this day, and so didst win for
-\v 21 Thyself the renown that is Thine to-day; and Thou
+Thyself the renown that is Thine to-day;
+\v 21 and Thou
 didst bring Thy people Israel out of the land of Egypt
 by signs and wonders, with mighty hand and
 \v 22 outstretched arm and terrors great; and Thou gavest them
 this land which Thou didst swear to their fathers to
-give them – a land flowing with milk and honey – and
-\v 23 they came in and took possession of it. But they would
+give them – a land flowing with milk and honey –
+\v 23 and
+they came in and took possession of it. But they would
 not listen to Thy voice, nor live in accordance with Thy
 law; they have left undone all that Thou didst command
 them to do; and so Thou hast brought all this
@@ -4176,7 +4360,8 @@ are already close upon it, and under the stress of
 sword, famine and pestilence, the city is already as good
 as given into the hands of the Chaldeans that are assailing
 it. What Thou hast threatened has come, as
-\v 25 Thou Thyself seest. And it was Thou Thyself, O
+Thou Thyself seest.
+\v 25 And it was Thou Thyself, O
 Lord Jehovah, who didst command me to buy the land;
 (and this I have done), writing and sealing the deed
 and calling witnesses, though all the while the city is
@@ -4189,28 +4374,36 @@ Chaldeans."
 
 \p
 \v 26 Then there came to Jeremiah the following message
-\v 27 from Jehovah: I am Jehovah, the God of all flesh: is
-\v 28 there anything too hard for Me? Therefore thus saith
+from Jehovah:
+\v 27 I am Jehovah, the God of all flesh: is
+there anything too hard for Me?
+\v 28 Therefore thus saith
 Jehovah: Behold! I am about to deliver this city into
 the hands of the Chaldeans and of Nebuchadrezzar,
-\v 29 king of Babylon, and he shall take it. Yes, the
+king of Babylon, and he shall take it.
+\v 29 Yes, the
 Chaldeans that are assailing this city shall come and set
 this city on fire and burn it, with the houses on whose
 roofs they have provoked Me by burning sacrifice to
 the Baal and by offering drink-offerings to other
-\v 30 gods; for, ever since their youth the people of Israel
+gods;
+\v 30 for, ever since their youth the people of Israel
 and Judah have done nothing but evil in My sight.
 \v 31 From the day it was built up to this day, this city has
 provoked Me to remove it, in wrath and fury, out of
-\v 32 My sight, for all the evil that the people of Israel and
+My sight,
+\v 32 for all the evil that the people of Israel and
 Judah have wrought to vex Me – themselves, with their
 kings, princes, priests and prophets, with the men of
-\v 33 Judah and the citizens of Jerusalem. They have
+Judah and the citizens of Jerusalem.
+\v 33 They have
 turned their backs to Me instead of their faces; and
 though I taught them early and late, they would never
-\v 34 listen or accept correction. The very House that
+listen or accept correction.
+\v 34 The very House that
 bears My name they have defiled by introducing
-\v 35 into it their abominable worship. They have built
+into it their abominable worship.
+\v 35 They have built
 Baal sanctuaries in the Valley of the son of Hinnom
 for the (fiery) consecration of their sons and daughters
 to Molech, though this was no commandment of
@@ -4225,15 +4418,19 @@ do this abomination, and thus involve Judah in sin.
 \v 36 Now, therefore, Thus saith Jehovah, the God of Israel,
 concerning the city of which ye say that hunger,
 famine and pestilence have already as good as delivered
-\v 37 it into the hands of the king of Babylon: See! I will
+it into the hands of the king of Babylon:
+\v 37 See! I will
 gather them out of all the lands to which, in My great
 wrath, anger, and fury, I have driven them, for I will
 bring them back to this place and settle them here
-\v 38 securely; and they shall be My people, and I will be
-\v 39 their God. A single heart I will give them, and a single
+securely;
+\v 38 and they shall be My people, and I will be
+their God.
+\v 39 A single heart I will give them, and a single
 way (will I set before them), that they may hold Me
 in reverence for ever, and that they and their children
-\v 40 after them may prosper; and I will make with them
+after them may prosper;
+\v 40 and I will make with them
 an everlasting covenant to follow them ceaselessly
 with My blessing, and I will put the fear of Me in their
 hearts, that they may follow Me without swerving.
@@ -4246,7 +4443,8 @@ upon this people all this mass of misery, so surely will I
 bring upon them all the blessings I promise them.
 \v 43 In this land that ye call a desolation, forsaken of man
 and beast and delivered into the hands of the Chaldeans,
-\v 44 fields shall be bought once more. Yes, men
+fields shall be bought once more.
+\v 44 Yes, men
 shall buy fields for money, subscribing and sealing the
 deeds, and taking witnesses, in the district of Benjamin
 and the neighbourhood of Jerusalem and the cities of
@@ -4266,8 +4464,9 @@ Jehovah.
 
 \p
 \v 1 A second message from Jehovah came to Jeremiah
-\v 2 while he was still confined in the guard-house. It
-was this: Thus saith Jehovah, who created the earth
+while he was still confined in the guard-house. It
+was this:
+\v 2 Thus saith Jehovah, who created the earth
 and formed it to stand fast – Jehovah is His name:
 \p
 \v 3 "Call to Me, and in answer I will tell thee great and
@@ -4276,17 +4475,21 @@ hidden things, of which thou art unaware."
 \v 4 Thus saith Jehovah, the God of Israel, concerning
 the houses of this city and the royal palaces of Judah
 which have been demolished to make a defence against
-\v 5 the siege-mounds and the sword. The Chaldeans are
+the siege-mounds and the sword.
+\v 5 The Chaldeans are
 coming to fight and to fill them with the dead bodies
 of the men whom I have slain in Mine anger and fury,
 and whose manifold wickedness has constrained Me
-\v 6 to hide My face from them. Nevertheless, I will close
+to hide My face from them.
+\v 6 Nevertheless, I will close
 up the city's wounds and heal her completely, and I
 will unveil to them treasures of peace and stability.
 \v 7 The fortunes of Judah and Israel I will restore; and I
-\v 8 will build them up as of old. I will cleanse them of all
+will build them up as of old.
+\v 8 I will cleanse them of all
 the guilt of their sin against Me, and I will forgive all
-\v 9 the guilt of their sin and rebellion against Me. And
+the guilt of their sin and rebellion against Me.
+\v 9 And
 she shall be to Me a source of delight, of praise, and of
 glory among all the nations of the earth, when they hear
 of all the happiness that I shall achieve for them; and
@@ -4296,7 +4499,8 @@ the prosperity that I shall provide for them.
 \v 10 Thus saith Jehovah: In this place that you call a
 desolation, forsaken of man and beast, in the cities of
 Judah and on the streets of Jerusalem that are desolate,
-\v 11 forsaken of man and beast, there shall once again be
+forsaken of man and beast,
+\v 11 there shall once again be
 heard the voice of mirth and gladness, the voice of
 bridegroom and bride, the voice of those that say, as they
 bring their thank-offerings into the House of Jehovah,
@@ -4304,7 +4508,8 @@ bring their thank-offerings into the House of Jehovah,
 \q2 For Jehovah is gracious,
 \q2 His kindness endureth for ever.
 For I will restore the fortunes of the land, saith
-\v 12 Jehovah, as in the olden time. Thus saith Jehovah of
+Jehovah, as in the olden time.
+\v 12 Thus saith Jehovah of
 Hosts: In this place which is desolate, forsaken of
 man and beast, and in all the cities thereof, there shall
 again be homesteads of shepherds with flocks reclining.
@@ -4321,7 +4526,8 @@ shepherds), saith Jehovah.
 \p
 \v 14 Mark this, saith Jehovah; the days are coming when I will
 perform My gracious promise to the households of Israel and
-\v 15 Judah. In those days and at that time
+Judah.
+\v 15 In those days and at that time
 I will raise up for David a righteous shoot,
 \q2 Who shall execute justice and right in the land.
 \q
@@ -4336,7 +4542,8 @@ I will raise up for David a righteous shoot,
 
 \p
 \v 17 For thus saith Jehovah: David shall never want a man to sit
-\v 18 upon the throne of the house of Israel; neither shall the
+upon the throne of the house of Israel;
+\v 18 neither shall the
 Levitical priests ever, for all time to come, want a man to
 offer burnt-offerings in My presence or to burn oblations or to
 do sacrifice.
@@ -4344,20 +4551,25 @@ do sacrifice.
 \v 19 Further, there came to Jeremiah this message from Jehovah,
 \v 20 Thus saith Jehovah: Not until ye can annul My covenant with
 Day and Night, so that Day and Night shall come no more at
-\v 21 their appointed time – not until then shall My covenant be
+their appointed time –
+\v 21 not until then shall My covenant be
 annulled with David My servant, that a son of his should reign
 upon his throne; or My covenant with the Levitical priests,
-\v 22 My ministers. Numberless as the host of heaven, measureless
+My ministers.
+\v 22 Numberless as the host of heaven, measureless
 as the sand of the sea, shall I multiply the descendants of
 David, My servant, and the Levitical priests, My ministers.
 \p
-\v 23 Jeremiah received this further message from Jehovah: Hast
-\v 24 thou observed what this people has been saying? They have
+\v 23 Jeremiah received this further message from Jehovah:
+\v 24 Hast
+thou observed what this people has been saying? They have
 said that Jehovah has cast off the two families of His choice,
 and in contempt for His people has ordained that they shall no
-\v 25 longer exist as a nation before Him? Well, thus saith
+longer exist as a nation before Him?
+\v 25 Well, thus saith
 Jehovah: As surely as I have created Day and Night and
-\v 26 determined the order of heaven and earth, so surely will I never
+determined the order of heaven and earth,
+\v 26 so surely will I never
 cast off the descendants of Jacob and of David My servant,
 or fail to select his descendants as rulers over the race of
 Abraham, Isaac and Jacob; for I will have compassion upon
@@ -4379,25 +4591,30 @@ them and restore their fortunes.
 Nebuchadrezzar, king of Babylon, and all his army,
 and all the kingdoms and nations of the earth that
 were under his dominion were fighting against
-\v 2 Jerusalem and all the cities of Judah: Thus saith
+Jerusalem and all the cities of Judah:
+\v 2 Thus saith
 Jehovah, the God of Israel, Go to Zedekiah, king of
 Judah, and say to him, Thus saith Jehovah: I am
 about to deliver this city into the hands of the king of
-\v 3 Babylon, who will burn it with fire. As for thee, thou
+Babylon, who will burn it with fire.
+\v 3 As for thee, thou
 shalt not escape out of his hands: thou wilt assuredly
 be seized and into his hands delivered: thou shalt see
 the king of Babylon eye to eye, and speak to him face
-\v 4 to face, and to Babylon thou shalt go. But listen,
+to face, and to Babylon thou shalt go.
+\v 4 But listen,
 Zedekiah, king of Judah, to the message of Jehovah:
 Thus saith Jehovah concerning thee: Thou shalt not
-\v 5 die by the sword, but thou shalt die in peace. (Sweet
+die by the sword,
+\v 5 but thou shalt die in peace. (Sweet
 spices) shall be burned for thee, as for thine ancestors
 before thee, and lamentations shall be made for thee
 with "Ah! Lord," for I, saith Jehovah, have spoken
 the word.
 \p
 \v 6 Then Jeremiah the prophet delivered this message to
-\v 7 Zedekiah king of Judah in Jerusalem, when the army
+Zedekiah king of Judah in Jerusalem,
+\v 7 when the army
 of the king of Babylon was fighting against Jerusalem,
 and all the cities of Judah that were left, and Lachish
 and Azekah – the only cities of Judah that remained as
@@ -4411,30 +4628,37 @@ Slaves: To be Punished by the Liberation of Disaster upon Themselves
 \p
 \v 8 The message which came to Jeremiah from Jehovah,
 after the King Zedekiah had covenanted with all the people
-\v 9 in Jerusalem to make a proclamation of liberty – each
+in Jerusalem to make a proclamation of liberty –
+\v 9 each
 man to set free his Hebrew slave, whether male or
 female, so that no one of Jewish descent should serve
-\v 10 as slave any longer. Now all the princes and all the
+as slave any longer.
+\v 10 Now all the princes and all the
 people kept the covenant they had entered into to
 liberate their several male and female slaves and to
 treat them as slaves no longer: they kept it and set
-\v 11 them free. Afterwards, however, they turned and
+them free.
+\v 11 Afterwards, however, they turned and
 forced back into slavery the male and female slaves
 whom they had liberated.
 \p
 \v 12 Then there came to Jeremiah this message from
-\v 13 Jehovah, Thus saith Jehovah, the God of Israel:
+Jehovah,
+\v 13 Thus saith Jehovah, the God of Israel:
 When I brought your forefathers out of the land of
 Egypt, that house of slavery, I Myself made this
-\v 14 covenant that at the end of six years they were to
+covenant
+\v 14 that at the end of six years they were to
 release any Hebrew brother who had sold himself to
 them – after six years of service, they were to set him
 free: your forefathers, however, would not listen
-\v 15 or incline their ear to Me. But you have in these days
+or incline their ear to Me.
+\v 15 But you have in these days
 acted in a very different spirit; you have done what
 I desired in each proclaiming liberty to his (enslaved)
 neighbour; in My presence you made a covenant
-\v 16 in the House that is called by My name. Now,
+in the House that is called by My name.
+\v 16 Now,
 however, you have turned round and dishonoured My
 name by forcing back again into slavery the several
 male and female slaves you had set free to dispose of
@@ -4446,16 +4670,20 @@ you to his (enslaved) neighbour. Well, then, saith
 Jehovah: You shall have your proclamation of liberty
 from Me – (liberty) to the sword, pestilence and
 famine – and I will make you an object of consternation
-\v 18 to every kingdom in the world. As for the men
+to every kingdom in the world.
+\v 18 As for the men
 that broke the covenant they had made in My presence,
 when they passed between the pieces of the calf they
-\v 19 had cut in two – I mean the princes of Judah and
+had cut in two –
+\v 19 I mean the princes of Judah and
 Jerusalem, the eunuchs, the priests and all the people of
 the land who passed between the pieces of the calf
-\v 20 they had cut in two – I will deliver them into the hands
+they had cut in two –
+\v 20 I will deliver them into the hands
 of their enemies and of those that seek their life, and
 their dead bodies shall be devoured by the birds of the
-\v 21 air and the beasts of the earth. Further, Zedekiah,
+air and the beasts of the earth.
+\v 21 Further, Zedekiah,
 king of Judah, and his princes, I will deliver into the
 hands of their enemies and of those that seek their life,
 and into the hands of the army of the king of Babylon
@@ -4477,64 +4705,81 @@ cities of Judah I will turn into an uninhabited desolation.
 \p
 \v 1 In the days of Jehoiakim, the son of Josiah, king of
 Judah, Jeremiah received the following message from
-\v 2 Jehovah: Go to the clan of the Rechabites, talk with
+Jehovah:
+\v 2 Go to the clan of the Rechabites, talk with
 them, bring them into one of the chambers (of the
-\v 3 Temple) and offer them wine to drink. So I took
+Temple) and offer them wine to drink.
+\v 3 So I took
 Jaazaniah, the son of Jeremiah, the son of Habaz-ziniah,
 with his brothers and all his sons and the whole
-\v 4 Rechabite clan, and brought them into the Temple
+Rechabite clan,
+\v 4 and brought them into the Temple
 chamber belonging to the sons of Hanan, the son of
 Yigdaliah, the man of God, that was adjacent to the
 chamber of the princes, above the chamber of
 Maaseiah, the son of Shallum, the Keeper of the
-\v 5 Threshold. I then set before the Rechabites bowls
-\v 6 full of wine and cups and told them to drink. "No,"
+Threshold.
+\v 5 I then set before the Rechabites bowls
+full of wine and cups and told them to drink.
+\v 6 "No,"
 they said, "we will drink no wine; for Jonadab, the
 son of Rechab, our ancestor, laid a charge upon us and
-\v 7 our children to drink no wine, to build no houses, to sow
+our children to drink no wine,
+\v 7 to build no houses, to sow
 no seed, to plant and possess no vineyard for ever, but to
 spend all our days in tents, so that we might live long on
-\v 8 the land where as strangers we dwell. In full obedience,
+the land where as strangers we dwell.
+\v 8 In full obedience,
 therefore, to this charge of Jonadab, the son of Rechab,
 our ancestor, we have drunk no wine all our life long,
 neither we, nor our wives, nor our sons, nor our
-\v 9 daughters. We have built no houses to live in, we
-\v 10 have owned neither vineyard, field, nor seed, but
+daughters.
+\v 9 We have built no houses to live in, we
+have owned neither vineyard, field, nor seed,
+\v 10 but
 we have lived in tents and faithfully fulfilled all the
-\v 11 instructions of our ancestors Jonadab. It was only
+instructions of our ancestors Jonadab.
+\v 11 It was only
 when the land was invaded by Nebuchadrezzar, king
 of Babylon, that we decided to come to Jerusalem, to
 escape the Babylonian and Aramean armies; that is
 why we are (now) living in Jerusalem."
 \p
 \v 12 Then there came to Jeremiah this message from
-\v 13 Jehovah: "Thus saith Jehovah the God of Israel:
+Jehovah:
+\v 13 "Thus saith Jehovah the God of Israel:
 Go and say to the men of Judah and the citizens of
 Jerusalem: Should this not be a lesson to you to obey
-\v 14 My words, saith Jehovah? The injunction that
+My words, saith Jehovah?
+\v 14 The injunction that
 Jonadab the son of Rechab laid upon his sons to
 drink no wine has been steadily observed: in obedience
 to that ancestral charge they have abstained to this day.
 But when I spoke to you early and late, you refused
-\v 15 to listen. Early and late I sent you all My servants the
+to listen.
+\v 15 Early and late I sent you all My servants the
 prophets with the message to each man of you that, if
 you would abandon your wicked ways, amend your
 conduct, and no longer indulge in the service of other
 gods, you should continue in the land that I gave your
 forefathers; but you would not incline your ear or
-\v 16 listen to Me. Unlike the descendants of Jonadab the
+listen to Me.
+\v 16 Unlike the descendants of Jonadab the
 son of Rechab, who have steadily observed the injunctions
 of their ancestor, this people has refused to
-\v 17 listen to Me. Therefore thus saith Jehovah of Hosts,
+listen to Me.
+\v 17 Therefore thus saith Jehovah of Hosts,
 the God of Israel: See! I am about to bring upon
 Judah and upon all the citizens of Jerusalem all the
 misery with which I have threatened them, because
 they refused to listen to My words or respond to My
-\v 18 call." But to the clan of the Rechabites Jeremiah said,
+call."
+\v 18 But to the clan of the Rechabites Jeremiah said,
 "Thus saith Jehovah of Hosts, the God of Israel:
 Because you have obeyed the injunction of your
 ancestor Jonadab, keeping all his commandments and
-\v 19 fulfiling all his instructions, Jonadab, the son of Rechab
+fulfiling all his instructions,
+\v 19 Jonadab, the son of Rechab
 shall never want a man to minister to Me, while the
 earth stands.
 
@@ -4550,11 +4795,13 @@ and Contemptuously Burned by King Jehoiakim
 \p
 \v 1 In the fourth year of Jehoiakim, the son of Josiah,
 king of Judah, Jeremiah received the following message
-\v 2 from Jehovah: Take a book-roll, and write on it all
+from Jehovah:
+\v 2 Take a book-roll, and write on it all
 the messages I have communicated to thee with regard
 to Israel and Judah and all nations, from My first
 message to thee in the days of Josiah right on to the
-\v 3 present day. It may be that, when the people of
+present day.
+\v 3 It may be that, when the people of
 Judah hear of all the misery I am planning to bring
 upon them, they will severally abandon their wicked
 ways, and receive at My hands pardon for their guilt
@@ -4563,18 +4810,22 @@ and sin.
 \v 4 Then Jeremiah summoned Baruch, the son of Neriah,
 who wrote down on a book-roll to Jeremiah's dictation
 all the messages Jehovah had communicated to
-\v 5 him. Thereafter Jeremiah gave instructions to
+him.
+\v 5 Thereafter Jeremiah gave instructions to
 Baruch in the following terms: "Seeing that I am
 personally under restraint and debarred from access
-\v 6 to the Temple, do you go and, on the day appointed
+to the Temple,
+\v 6 do you go and, on the day appointed
 for fasting, read aloud in the Temple the messages of
 Jehovah in the hearing of the people from the roll
 which you have written to my dictation; read them
 also in the hearing of the Judeans who come from their
-\v 7 respective country towns. It may be that they will
+respective country towns.
+\v 7 It may be that they will
 humbly supplicate Jehovah, and severally abandon
 their wicked ways: for great is the anger and fury
-\v 8 with which Jehovah has threatened this people." In
+with which Jehovah has threatened this people."
+\v 8 In
 accordance, therefore with his instructions from
 Jeremiah the prophet, Baruch read aloud from the
 book the words of Jehovah in the Temple.
@@ -4583,22 +4834,27 @@ book the words of Jehovah in the Temple.
 the son of Josiah, king of Judah, a sacred fast was
 proclaimed by all the people resident in Jerusalem,
 and all those also present from the country towns of
-\v 10 Judah. Then in the hearing of all the people Baruch
+Judah.
+\v 10 Then in the hearing of all the people Baruch
 read from the book the messages of Jeremiah from the
 room that belonged to Gemariah, the son of Shaphan
 the Secretary of State, which was situated in the upper
-\v 11 court at the entrance to the new Temple gate. Now
+court at the entrance to the new Temple gate.
+\v 11 Now
 when Micaiah, the son of Gemariah, the son of
 Shaphan, had heard the messages of Jehovah as they
-\v 12 were read from the book, he went down to the palace
+were read from the book,
+\v 12 he went down to the palace
 to the room of the Secretary of State, and there he found
 the whole court seated – Elishama, the Secretary and
 Delaiah, the son of Shemaiah, and Elanthan, the
 son of Achbor, and Gemariah, the son of Shaphan, and
 Zedekiah, the son of Hananiah, and indeed the whole
-\v 13 court. Micaiah proceeded to inform them of all the
+court.
+\v 13 Micaiah proceeded to inform them of all the
 words he had heard Baruch read out of the book in the
-\v 14 hearing of the people. The whole court accordingly
+hearing of the people.
+\v 14 The whole court accordingly
 despatched a messenger to Baruch, namely one Jehudi,
 the son of Nethaniah, the son of Shelemiah, the son of
 Cushi, with instructions to Baruch to appear, bringing
@@ -4607,16 +4863,21 @@ hearing of the people. So Baruch, the son of Neriah,
 appeared before them with the roll in his hand.
 \p
 \v 15 Then they told him to sit down and read it in their
-\v 16 hearing; so Baruch read while they listened. When
+hearing; so Baruch read while they listened.
+\v 16 When
 they had heard it all, they turned to one another in
 consternation, exclaiming to Baruch that they were
-\v 17 bound to inform the king of all this. They then
+bound to inform the king of all this.
+\v 17 They then
 asked Baruch to explain how he had written all these
-\v 18 words. Baruch replied that Jeremiah had dictated
+words.
+\v 18 Baruch replied that Jeremiah had dictated
 them all to him, and he had written them down with
-\v 19 ink in the book. "Well, then," said the princes to
+ink in the book.
+\v 19 "Well, then," said the princes to
 Baruch, "go into hiding, you and Jeremiah, and let
-\v 20 nobody know where you are." After they had
+nobody know where you are."
+\v 20 After they had
 deposited the roll in the chamber of Elishama the
 Secretary, they visited the king in his apartment,
 and reported the whole matter to him.
@@ -4624,19 +4885,24 @@ and reported the whole matter to him.
 \v 21 The king then despatched Jehudi to fetch the roll;
 and, when he had brought it from Elishama's chamber,
 he read it in the hearing of the king and of all the
-\v 22 courtiers who were in attendance upon him. Now
+courtiers who were in attendance upon him.
+\v 22 Now
 the king was sitting in the winter house, and the
-\v 23 fire on the brazier was burning before him; and
+fire on the brazier was burning before him;
+\v 23 and
 every three or four columns that Jehudi read, the king
 would cut up with his penknife and fling into the fire
 that was on the brazier, till the whole roll was consumed
-\v 24 in the fire that was on the brazier. But there
+in the fire that was on the brazier.
+\v 24 But there
 was no sense of horror either on the part of the king
 or of any of his ministers as they listened to all these
-\v 25 words, nor did they rend their garments. Elnathan,
+words, nor did they rend their garments.
+\v 25 Elnathan,
 Delaiah, and Gemariah, however, had entreated the
 king not to burn the roll, but he would not listen to
-\v 26 them. Then the king commanded the royal prince
+them.
+\v 26 Then the king commanded the royal prince
 Jerachmeel, and Seraiah, the son of Azriel, and
 Shelemiah, the son of Abdeel, to fetch Baruch the scribe
 and Jeremiah the prophet; but Jehovah kept them in
@@ -4644,18 +4910,21 @@ concealment.
 \p
 \v 27 After the king had burned the roll containing the
 words written by Baruch to Jeremiah's dictation,
-\v 28 Jeremiah received this message from Jehovah, "Once
+Jeremiah received this message from Jehovah,
+\v 28 "Once
 more take another roll, and write on it all the words
 that were on the first roll that was consigned to the
-\v 29 flames by Jehoiakim, king of Judah, Thus saith
+flames by Jehoiakim, king of Judah,
+\v 29 Thus saith
 Jehovah: Thou hast taken it upon thee to burn this
 roll and to demand my reason for recording the threat
 that the king of Babylon would assuredly come and
-\v 30 destroy this land, and clear it of man and beast.
-Therefore thus saith Jehovah concerning Jehoiakim, king of
+destroy this land, and clear it of man and beast.
+\v 30 Therefore thus saith Jehovah concerning Jehoiakim, king of
 Judah: Never a man shall he have to sit upon the
 throne of David; his dead body shall be flung out and
-\v 31 exposed to the heat of day and the cold of night. I
+exposed to the heat of day and the cold of night.
+\v 31 I
 will punish him, his descendants, and his ministers, for
 their sins; and I will bring upon them and upon the
 citizens of Jerusalem all the misery with which I
@@ -4685,11 +4954,13 @@ of Coniah, the son of Jehoiakim, having been set upon
 the throne of Judah by Nebuchadrezzar, king of Babylon;
 \v 2 but neither he nor his ministers nor the people
 of the land gave any heed to the messages Jehovah
-\v 3 had delivered by the prophet Jeremiah. King
+had delivered by the prophet Jeremiah.
+\v 3 King
 Zedekiah, however, sent Jehucal the son of Shelemiah,
 and Zephaniah the son of Maaseiah the priest to
 Jeremiah, with the request that he would pray for
-\v 4 them to Jehovah their God. Now Jeremiah, who had
+them to Jehovah their God.
+\v 4 Now Jeremiah, who had
 not yet been put in prison, was still coming and
 going among the people.
 \p
@@ -4697,15 +4968,19 @@ going among the people.
 Jerusalem, having received a report that Pharaoh's
 army was advancing from Egypt, abandoned the siege.
 \v 6 Then there came to Jeremiah this message from
-\v 7 Jehovah, Thus saith Jehovah: Tell the king of
+Jehovah,
+\v 7 Thus saith Jehovah: Tell the king of
 Judah who hath sent thee to consult Me, that
 Pharaoh's army which is advancing to your aid
-\v 8 shall return to Egypt to their own land; and the
+shall return to Egypt to their own land;
+\v 8 and the
 Chaldeans will come back and assault this city
-\v 9 and take it and burn it with fire. Thus saith Jehovah:
+and take it and burn it with fire.
+\v 9 Thus saith Jehovah:
 Do not delude yourselves with the idea that the Chaldeans
 will leave you for good: they will do nothing of
-\v 10 the kind. For even if you defeated the whole
+the kind.
+\v 10 For even if you defeated the whole
 Chaldean army that is fighting against you, so completely
 that the only survivors were wounded men – a
 man to a tent– even they would rise up and burn this
@@ -4719,19 +4994,24 @@ city with fire.
 \p
 \v 11 When, in view of the advance of Pharoah's army,
 the Chaldean forces had abandoned the siege of
-\v 12 Jerusalem, Jeremiah made a journey from Jerusalem
+Jerusalem,
+\v 12 Jeremiah made a journey from Jerusalem
 to the district of Benjamin to receive his inheritance
-\v 13 among the people. He had just reached the Benjamin
+among the people.
+\v 13 He had just reached the Benjamin
 gate when he was apprehended there by a sentry
 named Jirijah, the son of Shelemiah, the son of
 Hananiah, who called out, "You are deserting to the
-\v 14 Chaldeans." "It is false, said Jeremiah, "I am
+Chaldeans."
+\v 14 "It is false, said Jeremiah, "I am
 not deserting to the Chaldeans." But Jirijah, refusing
 to listen, apprehended Jeremiah and brought him
-\v 15 before the courtiers, who in their exasperation had
+before the courtiers,
+\v 15 who in their exasperation had
 Jeremiah flogged and put in the house of Jonathan,
 the Secretary of State, which they had turned into a
-\v 16 prison. So Jeremiah found himself in the cells of the
+prison.
+\v 16 So Jeremiah found himself in the cells of the
 dungeon, where he remained for a considerable time.
 
 
@@ -4744,15 +5024,19 @@ dungeon, where he remained for a considerable time.
 him secretly in his house whether there was any
 communication from Jehovah. "There is," said Jeremiah;
 "you will be delivered into the hands of the king of
-\v 18 Babylon. Further," said Jeremiah to the king,
+Babylon.
+\v 18 Further," said Jeremiah to the king,
 "what is my crime against you or your ministers or
-\v 19 this people that you have put me in prison? Where
+this people that you have put me in prison?
+\v 19 Where
 are your prophets (now) that assured you that the king
-\v 20 of Babylon would never invade this country? And
+of Babylon would never invade this country?
+\v 20 And
 now I beseech your Majesty to listen with favour to my
 supplication, and not to allow me to be taken back
 to the house of Jonathan the Secretary, where I am
-\v 21 likely to perish." Jeremiah was accordingly committed
+likely to perish."
+\v 21 Jeremiah was accordingly committed
 by royal command to the guard-court, and furnished
 with a loaf of bread a day from the Baker's Street, till
 all the bread in the city was consumed. So Jeremiah
@@ -4771,20 +5055,25 @@ Rescued by Ebedmelech, a Foreigner
 \v 1 Now Shephatiah, the son of Mattan, and Gedaliah, the
 son of Pashhur, and Juca, the son of Shelemiah, and
 Pashhur, the son of Malchiah, and heard Jeremiah
-\v 2 addressing all the people in words like these: "Thus
+addressing all the people in words like these:
+\v 2 "Thus
 saith Jehovah: Whoever remains in this city shall die
 by sword, famine and perstilence; but whoever goes
 over to the Chaldeans shall be spared, though he shall
-\v 3 escape with nothing but his life." Also, "Thus saith
+escape with nothing but his life."
+\v 3 Also, "Thus saith
 Jehovah, This city shall most assuredly be delivered
 into the hands of the king of Babylon's army, and
-\v 4 it shall be captured." Whereupon those courtiers
+it shall be captured."
+\v 4 Whereupon those courtiers
 said to the king, "We petition you to have this fellow
 put to death: this sort of talk is unnerving all the
 people and the soldiers left in the city. This fellow
-\v 5 does not want to help the city, but to ruin it." "He
+does not want to help the city, but to ruin it."
+\v 5 "He
 is in your power," said the king; for he was helpless
-\v 6 against them. So they took Jeremiah and, lowering
+against them.
+\v 6 So they took Jeremiah and, lowering
 him with ropes, they threw him into the cistern of the
 royal prince Malchiah, that was in the guard-court.
 There was no water in the cistern, but only mud;
@@ -4792,23 +5081,28 @@ and Jeremiah sank in the mud.
 \p
 \v 7 Now it came to the ears of Ebedmelech, an Ethiopian
 eunuch attached to the palace, that they had put
-\v 8 Jeremiah in the cistern. Ebedmelech accordingly left
+Jeremiah in the cistern.
+\v 8 Ebedmelech accordingly left
 the palace for the Benjamin gate where the king
 happened to be sitting at the time, and thus he
-\v 9 addressed him: "Your Majesty, these men have
+addressed him:
+\v 9 "Your Majesty, these men have
 behaved most wrongfully in their treatment of Jeremiah
 the prophet; they have flung him into the cistern and
 he will die of hunger on the spot, for there is no more
-\v 10 bread in the city." At once the king ordered
+bread in the city."
+\v 10 At once the king ordered
 Ebedmelech to take with him three me and pull
 Jeremiah out of the cistern before he perished.
 \v 11 Ebedmelech, accordingly, taking the men with him,
 went to the palace, and secured from (a lumber room)
 underneath the treasury some torn and tattered rags,
 and let them down by ropes to Jeremiah into the
-\v 12 cistern. Then he told Jeremiah to put the torn and
+cistern.
+\v 12 Then he told Jeremiah to put the torn and
 tattered rags under his armpits beneath the ropes;
-\v 13 and Jeremiah did so. Then they drew him up with the
+and Jeremiah did so.
+\v 13 Then they drew him up with the
 ropes and pulled him out of the cistern; and Jeremiah
 remained in the guard-court.
 
@@ -4822,18 +5116,22 @@ remained in the guard-court.
 brought to him at the third entry that leads into the
 Temple; and the king said to Jeremiah, "I am going
 to ask you a question which you are to answer me
-\v 15 unreservedly." "If I tell you," said Jeremiah, "are
+unreservedly."
+\v 15 "If I tell you," said Jeremiah, "are
 you not certain to put me to death? besides, any advice
-\v 16 I give you, you will simply disregard." Then, in secret,
+I give you, you will simply disregard."
+\v 16 Then, in secret,
 the king swore the following oath to Jeremiah, "As
 Jehovah liveth, who created this life of ours, I assure
 you solemnly that I will neither put you to death nor
 deliver you into the hands of those men that are seeking
-\v 17 your life." Then said Jeremiah to Zedekiah,
+your life."
+\v 17 Then said Jeremiah to Zedekiah,
 "Thus saith Jehovah, If you surrender voluntarily to
 the officers of the king of Babylon, your life will be
 spared, and this city shall not be burned with fire, but
-\v 18 you and your family will be spared. If, however, you
+you and your family will be spared.
+\v 18 If, however, you
 refuse to surrender, then this city shall be delivered
 into the hands of the Chaldeans, who will burn it with
 fire; and you shall not escape from their hands."
@@ -4842,9 +5140,11 @@ Jews who have gone over to them and subjected to violence."
 \v 20 "No," said Jeremiah, "you will not be handed over.
 But I entreat you to listen to what I say – it is the
 voice of Jehovah: your happiness and your life depend
-\v 21 upon it. But if you refuse to surrender, then this is
+upon it.
+\v 21 But if you refuse to surrender, then this is
 the message revealed to me in a vision by Jehovah
-\v 22 –mark it well; (I saw) all the women that are left in
+–
+\v 22 mark it well; (I saw) all the women that are left in
 the palace of the king of Judah brought out to the chief
 officers of the king of Babylon, chanting the while this
 song:
@@ -4860,13 +5160,16 @@ this city shall be burned with fire."
 \p
 \v 24 "Well, then," said the king to him, "let nobody
 know anything of this conversation, or else you are a dead
-\v 25 man. If the courtiers hear that I have been talking
+man.
+\v 25 If the courtiers hear that I have been talking
 with you, and come and ask you to tell them unreservedly,
 on pain of death, what you have been saying
-\v 26 to the king and the king to you, then just tell them that
+to the king and the king to you,
+\v 26 then just tell them that
 you were presenting a petition to the king that you
 should not be taken back to Jonathan's house, where
-\v 27 you were in danger of perishing." In point of fact, the
+you were in danger of perishing."
+\v 27 In point of fact, the
 courtiers did all come to Jeremiah and question him;
 and the story he told them was in entire accordance
 with the king's instructions. So they said no more to
@@ -4891,12 +5194,14 @@ till the day Jerusalem was taken.
 \v 1 In the tenth month of the ninth year of Zedekiah,
 king of Judah, Nebuchadrezzar, king of Babylon came
 with all his forces against Jerusalem and laid siege to
-\v 2 it. On the ninth day of the fourth month of the
+it.
+\v 2 On the ninth day of the fourth month of the
 eleventh year of Zedekiah a breach was made in the
 \v 3 the king of Babylon came and took their seats
 in the middle gate – Nergalsharezer the Rab-mag,
 Nebushazban the Rab-saris, and all the rest of the
-\v 4 city. On observing this, Zedekiah, king of Judah, and
+city.
+\v 4 On observing this, Zedekiah, king of Judah, and
 all the soldiers took to flight, leaving the city during the
 night by way of the royal garden, by the gate between
 the two walls, and they made for the Jordan valley.
@@ -4929,7 +5234,8 @@ Nebuzaradan, the commander of the guard, and
 Nebuzaradan, the Rab-saris, and Nergalsharezer, the
 Rab-mag, and all the chief officers of the king of
 Babylon.
-\v 14 Officers of the king of Babylon. They sent and had
+Officers of the king of Babylon.
+\v 14 They sent and had
 Jeremiah brought from the guard-court, and delivered
 him to Gedaliah, the son of Ahikam, the son of
 Shaphan, to be taken to his own home; so he stayed
@@ -4947,9 +5253,11 @@ there had come to him this message from Jehovah:
 Jehovah of Hosts, the God of Israel: I will bring upon
 this city all that I have said – for evil and not for good,
 and in that day it will be accomplished before thine
-\v 17 eyes. But, saith Jehovah, I will deliver thee on that
+eyes.
+\v 17 But, saith Jehovah, I will deliver thee on that
 day, and thou shalt not be given into the hands of the
-\v 18 men thou dreadest. I will save thee without fail;
+men thou dreadest.
+\v 18 I will save thee without fail;
 thou shalt not fall by the sword, but thou shalt escape
 with thy life, because, saith Jehovah, thou hast put
 thy trust in Me.
@@ -4974,14 +5282,17 @@ Judah, who were being carried to exile in Babylon.
 \p
 \v 2 The commander of the guard took Jeremiah and said
 to him: "Jehovah, your God, pronounced this doom
-\v 3 upon this place, and He has kept His word. You
+upon this place,
+\v 3 and He has kept His word. You
 have sinned against Him and refused to listen to His
-\v 4 voice, and so this thing is come upon you. But see now,
+voice, and so this thing is come upon you.
+\v 4 But see now,
 I will release you at once from the chains on your hands.
 If you are disposed to accompany me to Babylon
 come and I will look well after you; but if not, then
 leave it alone. The whole land is before you; go
-\v 5 wherever you choose and prefer. Go back to Gedaliah,
+wherever you choose and prefer.
+\v 5 Go back to Gedaliah,
 the son of Ahikam, the son of Shaphan, whom the king
 of Babylon has appointed Governor of the cities of
 Judah: stay with him among the people or go wherever
@@ -5000,38 +5311,46 @@ field, together with their men, heard that the king of
 Babylon had appointed Gedaliah Governor of the land,
 and charged him with the oversight of the men, women
 and children, and of the poorest of the land, such as
-\v 8 had not been carried to exile in Babylon, they came
+had not been carried to exile in Babylon,
+\v 8 they came
 with their men to Gedaliah at Mizpah – Ishmael the
 son of Nethaniah, Johanan and Jonathan the sons of
 Kareah, Seraiah the son of Tanhumeth, and the sons of
 Ephai of Netophah, and Jezaniah, the son of the
-\v 9 Maacathite. And Gedaliah gave his oath to them and
+Maacathite.
+\v 9 And Gedaliah gave his oath to them and
 their men: "Don't be afraid," he said, "of the
 Chaldean officials. You will prosper if you stay in the
-\v 10 land and serve the king of Babylon. As for myself,
+land and serve the king of Babylon.
+\v 10 As for myself,
 I will reside at Mizpah, to represent your interests
 when the Chaldean (officials) visit us; and you can
 gather wine, fruit, and oil, and store them up and live
-\v 11 in the towns you take possession of." Further, all the
+in the towns you take possession of."
+\v 11 Further, all the
 Jews that were in Moab, Ammon, Edom, or elsewhere,
 when they heard that the king of Babylon had granted
 permission to some to remain in Judah and had appointed
-\v 12 Gedaliah the son of Ahikam Governor, they
+Gedaliah the son of Ahikam Governor,
+\v 12 they
 all returned to Judah from all the places to which they
 had been driven – to Gedaliah at Mizpah – and they
 gathered immense stores of wine and fruit.
 \p
 \v 13 Now Johanan the son of Kareah and all the commanders
 of the forces in the open field came to Gedaliah
-\v 14 at Mizpah, and asked him whether he was aware
+at Mizpah,
+\v 14 and asked him whether he was aware
 that Baalis king of Ammon had sent Ishmael the son of
 Nethaniah to assasiante him. But Gedaliah would
-\v 15 not believe it. Then Johanan, in a secret audience with
+not believe it.
+\v 15 Then Johanan, in a secret audience with
 Gedaliah at Mizpah, said to him: "I beseech you to
 allow me to go and slay Ishmael. Nobody need know.
 Why should he take your life? that will mean the
 scattering of all the Jews that have gathered round
-\v 16 you, and the ruin of all that is left of Judah." "No,"
+you, and the ruin of all that is left of Judah."
+\v 16 "No,"
 said Gedaliah to Johanan, "do nothing of the kind:
 what you say of Ishmael is not true."
 
@@ -5044,7 +5363,8 @@ what you say of Ishmael is not true."
 of Nethaniah, the son of Elishama, a member of the
 royal family, accompanied by one of the chief officers of
 the king and ten (other) men, paid a visit to Gedaliah
-\v 2 at Mizpah. While they were all dining together there,
+at Mizpah.
+\v 2 While they were all dining together there,
 Ishmael and the ten men who accompanied him rose
 and with the sword smote and slew Gedaliah, whom the
 king of Babylon had appointed Governor of the land,
@@ -5058,20 +5378,25 @@ to be there.
 
 \p
 \v 4 The day after the murder of Gedaliah, of which no
-\v 5 one was yet aware, eighty pilgrims from Shechem,
+one was yet aware,
+\v 5 eighty pilgrims from Shechem,
 Shiloh, and Samaria, with beards shaven, clothes rent
 and gashes (on their bodies), came with vegetable offerings
 and frankincense in their hand to present them at
-\v 6 the house of Jehovah. Ishmael went out from Mizpah
+the house of Jehovah.
+\v 6 Ishmael went out from Mizpah
 to meet them, and they were weeping as they went
 along. When he meet them, he invited them to come to
-\v 7 Gedaliah; but when they were well within the town,
+Gedaliah;
+\v 7 but when they were well within the town,
 he and the men who accompanied him slew them at
-\v 8 the cistern. Ten of their number, however, entreated
+the cistern.
+\v 8 Ten of their number, however, entreated
 Ishmael not to kill them: "for we have stores of
 wheat," they said, "and barley, oil, and honey, buried
 in the ground." So he let them alone and did not
-\v 9 consign them to the doom of their brethren. Now
+consign them to the doom of their brethren.
+\v 9 Now
 the cistern into which Ishmael had cast all the corpses
 of the men he had slain was the great cistern which
 had been constructed by king Asa in his war against
@@ -5083,15 +5408,21 @@ people that were at Mizpah, the princesses and all the
 people left in Mizpah, whom Nebuzaradan, the commander
 of the guard, had committed to the charge of
 Gedaliah, the son of Ahikam; and he started across to
-\v 11 Ammon. But when Johanan the son of Kareah, and
+Ammon.
+\v 11 But when Johanan the son of Kareah, and
 all the commanders of the forces that were with him,
-\v 12 heard of all the atrocities perpetrated by Ishmael, they
+heard of all the atrocities perpetrated by Ishmael,
+\v 12 they
 took all their men and set out to attack him; and they
-\v 13a found him by the great waters of Gibeon. All the
-\v 14a people with Ishmael – all that he had carried captive
-\v 13b from Mizpah – when they saw Johanan and the commanders
+found him by the great waters of Gibeon.
+\v 13a All the
+people with Ishmael –
+\v 14a all that he had carried captive
+from Mizpah –
+\v 13b when they saw Johanan and the commanders
 of the forces that were with him, were filled
-\v 14b with joy; and turning about, they came back and
+with joy;
+\v 14b and turning about, they came back and
 \v 15 joined Johanan. But Ishmael, escaping with eight
 men, repaired to Ammon.
 \p
@@ -5100,10 +5431,12 @@ that were with him, tool all the rest of the people whom
 Ishmael had carried away captive from Mizpah, after
 his assassination of Gedaliah the son of Ahikam – men,
 women, and eunuchs, whom he had brought back from
-\v 17 Gibeon. Then they took their journey and stayed
+Gibeon.
+\v 17 Then they took their journey and stayed
 awhile at the sheepfolds of Chimham in the neighbourhood
 of Bethlehem, from which they intended to
-\v 18 travel to Egypt; for they were in terror of the
+travel to Egypt;
+\v 18 for they were in terror of the
 Chaldeans, because Ishmael had assassinated Gedaliah,
 whom the king of Babylon had appointed Governor of
 the land.
@@ -5118,12 +5451,14 @@ the land.
 
 \v 1 Then all the commanders of the forces, together
 with Johanan, and Azariah, the son of Hoshaiah, and
-\v 2 all the people great and small, approached Jeremiah
+all the people great and small,
+\v 2 approached Jeremiah
 the prophet with a petition, which they commended to
 his most favourable consideration, that he would pray
 for them, remnant as they were, to Jehovah his God.
 "We are left," they said, "but a few out of many, as
-\v 3 you see with your own eyes. Let Jehovah your God
+you see with your own eyes.
+\v 3 Let Jehovah your God
 tell us the way we should go and the things we should do."
 \v 4 Jeremiah replied, "I have heard you; I promise to
 pray to Jehovah our God, as you request; and whatever
@@ -5131,42 +5466,52 @@ be Jehovah's answer I will tell you unreservedly."
 \v 5 Whereupon they said to Jeremiah, "Jehovah be our
 true and faithful Witness that we will act entirely in
 accordance with any message that Jehovah your God
-\v 6 may send us. We have sent you to Jehovah our God;
+may send us.
+\v 6 We have sent you to Jehovah our God;
 and, be it welcome or unwelcome, we will obey His
 voice, and so enjoy the prosperity that comes from
 obedience to the voice of Jehovah our God."
 \p
 \v 7 After an interval of ten days, Jeremiah received a
-\v 8 message from Jehovah. He accordingly summoned
+message from Jehovah.
+\v 8 He accordingly summoned
 Johanan and all the commanders of the forces that
 were with him, and all the people, small and great,
 \v 9 and thus he addressed them. "Thus saith Jehovah,
 the God of Israel, to whom you sent me to present your
-\v 10 supplication: If you remain quietly in this land, I will
+supplication:
+\v 10 If you remain quietly in this land, I will
 build you up and not throw you down; I will plant you
 and not pluck you up: for I am grieved at the misery
-\v 11 I have brought upon you. You are afraid of the king of
+I have brought upon you.
+\v 11 You are afraid of the king of
 Babylon, but do not be afraid of him, saith Jehovah;
 do not be afraid of him, for I will be with you, to save
-\v 12 you and to deliver you from his hand. I will have
+you and to deliver you from his hand.
+\v 12 I will have
 pity upon you and inspire him with pity for you, so
 that he will allow you to remain in your own land.
 \v 13 You may, however, disregard the voice of Jehovah your
-\v 14 God, and refuse to remain in this land: you may say,
+God, and refuse to remain in this land:
+\v 14 you may say,
 'No; we will go to the land of Egypt, where we shall
 see no war and hear no sound of trumpet and never
 suffer for lack of bread – and there we shall make our
-\v 15 home.' In that case I call upon you that are left of
+home.'
+\v 15 In that case I call upon you that are left of
 Judah to listen to the message of Jehovah. Thus saith
 Jehovah of Hosts, the God of Israel: If you are really
 determined to proceed to Egypt, and if you go and settle
-\v 16 there, then the sword that you fear shall overtake you
+there,
+\v 16 then the sword that you fear shall overtake you
 there in the land of Egypt, and the hunger that you
 dread shall cling to your heels there in Egypt, and there
-\v 17 ye shall die; and all the men that were determined
+ye shall die;
+\v 17 and all the men that were determined
 to go and settle in Egypt shall die by the sword, famine,
 and pestilence; not one shall survive or escape the
-\v 18 disaster that I will bring upon them. For thus saith
+disaster that I will bring upon them.
+\v 18 For thus saith
 Jehovah of Hosts, the God of Israel: As Mine anger
 and fury have been poured out upon the inhabitants of
 Jerusalem, so shall My fury be poured out upon you
@@ -5176,14 +5521,17 @@ shall see this place no more.
 \p
 \v 19 This is Jehovah's message to you that are left of
 Judah: 'Do not go to Egypt.' But now be very sure
-\v 20 of this – I this day lay witness against you; you have
+of this – I this day lay witness against you;
+\v 20 you have
 done yourselves a grievous wrong. You have sent
 me to Jehovah your God with the request that I should
 pray for you to Jehovah, and promising to act in
 entire accordance with the will of Jehovah when I
-\v 21 declared it to you; but when I did declare it this day,
+declared it to you;
+\v 21 but when I did declare it this day,
 you refused to listen to the voice of Jehovah in respect
-\v 22 of any part of my commission. Now therefore be very
+of any part of my commission.
+\v 22 Now therefore be very
 sure of this, that ye shall die by the sword, famine,
 and pestilence, in the land where it is your desire to
 go and settle."
@@ -5196,11 +5544,13 @@ go and settle."
 \p
 \v 1 When Jeremiah had finished addressing to the
 assembled people all these words with which Jehovah
-\v 2 had commissioned him, Azariah, the son of Hoshaiah,
+had commissioned him,
+\v 2 Azariah, the son of Hoshaiah,
 and Johanan the son of Kareah and all the defiant and
 insolent men exclaimed to Jeremiah, "You are a liar;
 you have no commission to us from Jehovah to warn
-\v 3 us against going and settling in Egypt; but it is Baruch
+us against going and settling in Egypt;
+\v 3 but it is Baruch
 the son of Neriah who is setting you on against us with
 the object of delivering us into the hands of the
 Chaldeans, to be killed or transported to Babylon."
@@ -5210,12 +5560,14 @@ which urged them to remain in the land of Judah.
 \v 5 Accordingly Johanan and all the commanders of the
 forces took all that were now left of Judah – those that
 had come back from all the nations to which they had
-\v 6 been driven, to settle in the land of Judah – the men,
+been driven, to settle in the land of Judah –
+\v 6 the men,
 the women, the princesses, and all the persons whom
 Nebuzaradan, the commander of the guard, had left
 in the charge of Gedaliah, the son of Ahikam, the son
 of Shaphan, including Jeremiah the prophet and Baruch
-\v 7 the son of Neriah; and, disregarding the voice of
+the son of Neriah;
+\v 7 and, disregarding the voice of
 Jehovah, they went to Egypt and arrived at Daphnae.
 
 
@@ -5224,17 +5576,21 @@ Jehovah, they went to Egypt and arrived at Daphnae.
 
 \p
 \v 8 In Daphnae Jeremiah received the following message
-\v 9 from Jehovah: "Take large stones in thy hand and
+from Jehovah:
+\v 9 "Take large stones in thy hand and
 hide them away in secret at the porch of Pharaoh's
 residence in Daphnae in the presence of a few of the
-\v 10 men of Judah, and say to them, Thus saith Jehovah:
+men of Judah,
+\v 10 and say to them, Thus saith Jehovah:
 Mark this well – I will send and bring Nebuchadrezzar
 the king of Babylon My servant, who shall set his
 throne above these stones thou hast buried and spread
-\v 11 his glistening tapestry over them. He shall come and
+his glistening tapestry over them.
+\v 11 He shall come and
 smite the land of Egypt, devoting to death those
 doomed to death, to captivity those doomed to captivity,
-\v 12 to the sword those doomed to the sword. He shall
+to the sword those doomed to the sword.
+\v 12 He shall
 kindle a fire in the temples of the gods of Egypt, he shall
 clear the land of Egypt, as a shepherd clears his mantle
 of vermin, and then he shall depart from it in comfort.
@@ -5253,20 +5609,25 @@ will burn with fire.
 \p
 \v 1 Concerning all the Jews whose home was in Egypt–
 at Migdol, Daphnae, Memphis, and in upper Egypt–
-\v 2 Jeremiah received the following message: "Thus
+Jeremiah received the following message:
+\v 2 "Thus
 saith Jehovah of Hosts, the God of Israel: Ye have
 seen with your own eyes all the misery that I have
 wrought upon Jerusalem and upon all the cities of
 Judah. Ye see what they are to-day – desolate and
-\v 3 uninhabited – as a consequence of their wicked
+uninhabited –
+\v 3 as a consequence of their wicked
 behaviour which provoked Mine indignation; for they
 went and burned sacrifice in the service of other gods,
 unknown alike to them or to you or your forefathers;
-\v 4 and that, though early and late I had been sending to you
+and that,
+\v 4 though early and late I had been sending to you
 My servants the prophets to warn you against these
-\v 5 abominable practices that I detest. But they refused
+abominable practices that I detest.
+\v 5 But they refused
 to listen or incline their ear: they would no abandon
-\v 6 their wickedness or cease sacrificing to other gods. And
+their wickedness or cease sacrificing to other gods.
+\v 6 And
 so Mine anger and fury were poured forth: it blazed in
 the cities of Judah and on the streets of Jerusalem, so
 that they became the waste and the desolation that
@@ -5284,22 +5645,26 @@ cursed and scorned by every nation in the world.
 \v 9 Have you forgotten the crimes of your forefathers and
 of the kings and princes of Judah, the crimes, too,
 your own wives committed in the land of Judah and on
-\v 10 the streets of Jerusalem? To this day they have
+the streets of Jerusalem?
+\v 10 To this day they have
 remained unhumbled and unafraid. They have not
 lived in accordance with My law or with the statutes
 I set before you and your forefathers.
 \v 11 Therefore thus saith Jehovah of Hosts, the God of
 Israel: Mark this – I will set My face against you for
-\v 12 Evil, to exterminate Judah utterly. I will take the
+Evil, to exterminate Judah utterly.
+\v 12 I will take the
 remnant of Judah that were determined to come and
 settle in the land of Egypt, and in the land of Egypt
 they shall all be consumed; they shall fall by the sword
 and by famine; small and great, they shall die by the
 sword and by famine, and they shall be an object of
-\v 13 execration and horror, of cursing and scorn; and,
+execration and horror, of cursing and scorn;
+\v 13 and,
 as I have punished Jerusalem by sword, famine, and
 pestilence, so will I punish those that have made Egypt
-\v 14 their home, that not a man of the remnant of Judah
+their home,
+\v 14 that not a man of the remnant of Judah
 which has come to settle in Egypt shall escape or
 survive to return to the land of Egypt for which
 they shall yearn; for none but a fugitive or two
@@ -5308,19 +5673,23 @@ shall return."
 \v 15 Then the great gathering, composed of all the men
 who were aware that their wives burned sacrifice to
 other gods, and all the women that were standing by,
-\v 16 replied to Jeremiah thus: "We refuse to listen to this
+replied to Jeremiah thus:
+\v 16 "We refuse to listen to this
 message of yours that you have communicated to us in
-\v 17 the name of Jehovah: but we will most assuredly
+the name of Jehovah:
+\v 17 but we will most assuredly
 keep our solemn oath to burn sacrifice to the Queen
 of Heaven and to pour out drink-offerings in her
 honour as we used to do – we and our fathers, our
 kings and our princes, in the cities of Judah and on the
 streets of Jerusalem. Then we had plenty of food, we
-\v 18 lived well and were untouched by misfortune. But
+lived well and were untouched by misfortune.
+\v 18 But
 ever since the day we ceased burning sacrifice to the
 Queen of Heaven and pouring out drink-offerings in
 her honour, we have been utterly destitute, and sword
-\v 19 and famine have consumed us. Yes," said the women,
+and famine have consumed us.
+\v 19 Yes," said the women,
 "as for our offering of sacrifice to the Queen of Heaven
 and pouring out drink-offerings in her honour – have
 we not had the approval of our husbands in making cakes
@@ -5333,10 +5702,12 @@ women. Then Jeremiah addressed them as follows:
 Judah and on the streets of Jerusalem – you and your
 fathers, your kings and your princes and commons;
 and is it not precisely this that rankled in the mind and
-\v 22 heart of Jehovah, till He could bear your wicked and
+heart of Jehovah,
+\v 22 till He could bear your wicked and
 abominable conduct no longer, with the result that your
 country is become the uninhabited desolation, the
-\v 23 horror, the curse that it is to-day? It is because you
+horror, the curse that it is to-day?
+\v 23 It is because you
 have offered such sacrifices, sinning against Jehovah,
 disobeying the voice of Jehovah, refusing to live in
 accordance with His laws. His statutes, His expressed
@@ -5345,22 +5716,26 @@ you."
 \p
 \v 24 Further, Jeremiah said to the people and the women
 assembled: "Listen to the message of Jehovah, all ye
-\v 25 Jews that are in the land of Egypt. Thus saith Jehovah
+Jews that are in the land of Egypt.
+\v 25 Thus saith Jehovah
 of Hosts, the God of Israel: Verily you women
 have indeed carried out your solemn resolve faithfully
 to perform the vows you have taken upon you, to burn
 sacrifice to the Queen of Heaven and to pour out
 drink-offerings in her honour. Well, then, keep your word
-\v 26 and perform your vows. But listen now to the world of
+and perform your vows.
+\v 26 But listen now to the world of
 Jehovah, all ye Jews who have made Egypt your home.
 Mark this well: I have sworn, saith Jehovah, by My
 great name, that never again in all the land of Egypt
 shall My name be uttered by the lips of any man of
 Judah in the oath 'As truly as the Lord Jehovah
-\v 27 liveth.' Mark! I am watching over them for evil
+liveth.'
+\v 27 Mark! I am watching over them for evil
 and not for good; and every man of Judah in the
 land of Egypt shall be consumed by the sword and by
-\v 28 famine, until there be an end of them. Some who
+famine, until there be an end of them.
+\v 28 Some who
 escape the sword in Egypt shall return to Judah, but
 they shall be few in number; and then all the remnant
 of Judah that have some to settle in Egypt shall know
@@ -5388,7 +5763,8 @@ enemy that sought his life."
 delivered to Baruch the son of Neriah, after he had
 written these words in a book to Jeremiah's dictation
 in the fourth year of Jehoiakim, the son of Josiah, king
-\v 2 of Judah. "This, Baruch, is the message to thee from
+of Judah.
+\v 2 "This, Baruch, is the message to thee from
 Jehovah, the God of Israel.
 \v 3 Thou hast said, 'Woe is me! for Jehovah
 \q2 to my pain hath added sorrow;
@@ -5580,9 +5956,9 @@ Judah.
 \p
 \v 1 The message concerning the Philistines which
 Jeremiah the prophet received from Jehovah, before
-Pharaoh smote Gaza. Thus saith Jehovah:
-\q
-\v 2 From the north, see! waters are rising,
+Pharaoh smote Gaza.
+\v 2 Thus saith Jehovah:
+\q From the north, see! waters are rising,
 \q2 They swell to a raging torrent:
 \q They will sweep o'er the land and its fulness,
 \q2 The city and (all) her inhabitants.
@@ -5718,7 +6094,8 @@ Pharaoh smote Gaza. Thus saith Jehovah:
 \v 21 Tell it by the Arnon that Moab is laid waste.
 \q2 Judgment is come upon the table-land – upon Holon,
 \q
-\v 22 Jahzah, and Mephaath, upon Dibon, Nebo, and Beth-diblathaim,
+Jahzah, and Mephaath,
+\v 22 upon Dibon, Nebo, and Beth-diblathaim,
 \q
 \v 23 upon Kiriathaim, Beth-gamul, and Beth-meon,
 \q
@@ -5906,7 +6283,8 @@ deserve to drink the cup must drink it nevertheless,
 how canst thou expect to go utterly unpunished?
 Nay, verily, thou shalt no escape, but drink it thou
 \q
-\v 13 shalt. For I have most solemnly sworn, saith Jehovah,
+shalt.
+\v 13 For I have most solemnly sworn, saith Jehovah,
 that Bozrah shall be a horror, a scorn, and a curse,
 and all her cities shall be perpetual wastes.
 \q
@@ -6616,16 +6994,21 @@ the prophet.
 Seraiah, the son of Neriah, the son of Mahseiah, who
 acted as quester-master, when he accompanied
 Zedekiah the king of Judah to Babylon in the fourth
-\v 60 Year of his reign. Now Jeremiah had recorded on a scroll
-\v 61 all the misery that was to come upon Babylon; and
+Year of his reign.
+\v 60 Now Jeremiah had recorded on a scroll
+all the misery that was to come upon Babylon;
+\v 61 and
 he said to Seraiah, "When you arrive at Babylon, see
-\v 62 that you read all these words, and say: 'Thine, O
+that you read all these words,
+\v 62 and say: 'Thine, O
 Jehovah, are these words; it is Thou that hast decreed
 the destruction of this place – that never again shall it
 be a home for man or beast, but that it shall remain a
-\v 63 desolation for ever.' When you have finished reading
+desolation for ever.'
+\v 63 When you have finished reading
 this scroll, tie a stone to it and throw it into the middle
-\v 64 of the Euphrates, with the words: 'Thus shall Babylon
+of the Euphrates, with the words:
+\v 64 'Thus shall Babylon
 sink, to rise no more, because of all the misery that I
 shall bring upon her.'"
 
@@ -6643,9 +7026,11 @@ shall bring upon her.'"
 \v 1 Zedekiah, who was twenty-one years of age when he
 came to the throne, reigned for eleven years in Jerusalem.
 His mother's name was Hamutal, a daughter of
-\v 2 Jeremiah of Libnah. His actions were offensive to
-Jehovah, exactly as Jehoiakim's had been, and
-\v 3 Jehovah was so angry with Jerusalem and Judah that
+Jeremiah of Libnah.
+\v 2 His actions were offensive to
+Jehovah, exactly as Jehoiakim's had been,
+\v 3 and
+Jehovah was so angry with Jerusalem and Judah that
 He cast them out of His sight; and Zedekiah revolted
 against the king of Babylon.
 \p
@@ -6653,23 +7038,29 @@ against the king of Babylon.
 year of his reign Nebuchadrezzar, king of Babylon,
 came with all his forces to storm Jerusalem. They
 pitched their camp against it, and surrounded it with
-\v 5 a siege-wall; so the city was under siege till the eleventh
-\v 6 year of king Zedekiah. In the ninth day of the fourth
+a siege-wall;
+\v 5 so the city was under siege till the eleventh
+year of king Zedekiah.
+\v 6 In the ninth day of the fourth
 month – the famine in the city being so severe that
-\v 7 there was no bread for the people of the land – a
+there was no bread for the people of the land –
+\v 7 a
 breach was made in the city, and all the soldiers took
 to flight, leaving the city during the night by way of the
 gate between the two walls by the royal garden–
 the city being surrounded by the Chaldeans – and they
-\v 8 made for the Jordan valley. But the Chaldean army
+made for the Jordan valley.
+\v 8 But the Chaldean army
 pursued the king and overtook him in the steppes of
 Jericho, all his own army having left him and scattered.
 \v 9 They seized the king and brought him to the king of
 Babylon who was at Riblah in the district of Hamath;
-\v 10 and he pronounced judgment upon him. At Riblah
+and he pronounced judgment upon him.
+\v 10 At Riblah
 the king of Babylon slew the sons of Zedekiah before
 his eyes, and all the princes of Judah did he also slay;
-\v 11 he then put out Zedekiah's eyes, and having loaded him
+he then put out Zedekiah's eyes,
+\v 11 and having loaded him
 with chains, he carried him to Babylon, where he kept
 him in the House of Discipline till the day of his death.
 \p
@@ -6678,13 +7069,15 @@ year of king Nebuchadrezzar, king of Babylon,
 Nebuzaradan the commander of the guard, one of the
 ministers of the king of Babylon, entered Jerusalem;
 \v 13 and he proceeded to burn the Temple, the palace, and
-\v 14 indeed every house in Jerusalem. All the walls that
+indeed every house in Jerusalem.
+\v 14 All the walls that
 encircled Jerusalem were demolished by the Chaldean
 forces that were under the commander of the guard.
 \v 15 The rest of the people left in the city, and the deserters
 who had gone over the king of Babylon, and those
 that were left of the artificers, were carried into exile by
-\v 16 Nebuzaradan the commander of the guard. Some of
+Nebuzaradan the commander of the guard.
+\v 16 Some of
 the poorest of the country people were left by Nebuzaradan,
 the commander of the guard, to act as vine-dressers
 and ploughmen.
@@ -6692,35 +7085,42 @@ and ploughmen.
 \v 17 The bronze pillars of the Temple, and the stands,
 and the bronze sea that was in the Temple, were broken
 in pieces by the Chaldeans, and all the bronze of them
-\v 18 was taken to Babylon. They also took the pots and
+was taken to Babylon.
+\v 18 They also took the pots and
 the shovels and the snuffers and the basons and the
 pans and all the bronze vessels used in the (Temple)
-\v 19 service. The goblets and the snuff-dishes (for the
+service.
+\v 19 The goblets and the snuff-dishes (for the
 lamps) and the basons and the pots and the lamp-stands
 and the pans and the libation bowls – whatever
 was of gold or silver respectively – were removed by the
-\v 20 commander of the guard: – the pillars, two; the sea
+commander of the guard: –
+\v 20 the pillars, two; the sea
 one; and the bronze bulls that supported the sea,
 twelve; and the stands which King Solomon had
 made for the Temple, ten; – vessels the mass of whose
-\v 21 bronze was beyond weight. Each of the pillars was
+bronze was beyond weight.
+\v 21 Each of the pillars was
 twenty-seven feet in height, eighteen feet in circumference,
 three inches in thickness, and hollow within.
 \v 22 It was surmounted by a bronze capital, seven feet and a
 half in height, round which ran network and pomegranates
 of bronze throughout; the (network and)
-\v 23 pomegranate adorment of both pillars was alike. On
+pomegranate adorment of both pillars was alike.
+\v 23 On
 the network round about there were a hundred pomegranates
 in all, of which ninety-six were visible.
 \p
 \v 24 The commander of the guard also took Seraiah the
 chief priest, and Zephaniah the second priest, and the
-\v 25 three keepers of the threshold. He took also from the
+three keepers of the threshold.
+\v 25 He took also from the
 city a eunuch who had charge of the soldiers, and seven
 of the King's Privy Councillors who were found in
 the city, and the secretary of the commander-in-chief,
 who kept the army register, and sixty of the people of
-\v 26 the land whom he found within the city. Having
+the land whom he found within the city.
+\v 26 Having
 seized them, Nebuzaradan, the commander of the guard,
 brought them to Riblah to the king of Babylon;
 \v 27 and the king of Babylon put them to death at Riblah
@@ -6729,9 +7129,11 @@ from her own land into exile.
 \p
 \v 28 These are the people whom Nebuchadrezzar carried
 into exile; in the seventeenth year (of his reign)
-\v 29 three thousand and twenty-three Jews; in the eighteenth
+three thousand and twenty-three Jews;
+\v 29 in the eighteenth
 year of Nebuchadrezzar, eight hundred and
-\v 30 thirty-two persons from Jerusalem; in the twenty-third
+thirty-two persons from Jerusalem;
+\v 30 in the twenty-third
 year of Nebuchadrezzar Nebuzaradan the
 commander of the guard carried seven hundred and
 forty-five Jews into exile: – in all, four thousand
@@ -6747,11 +7149,14 @@ six hundred.
 king of Judah, in the twenty-fifth day of the twelfth
 month, Evil-merodach, in the year of his accession to
 the throne of Babylon, restored Jehoiachin, king of
-\v 32 Judah, to favour, liberated him from prison, engaged
+Judah, to favour, liberated him from prison,
+\v 32 engaged
 him in friendly intercourse, and gave him precedence
 over the (other) kings who were (detained) with him
-\v 33 in Babylon. He also changed his prison dress, and he
-\v 34 dined at the royal table to the very end of his life. A
+in Babylon.
+\v 33 He also changed his prison dress, and he
+dined at the royal table to the very end of his life.
+\v 34 A
 perpetual allowance, which was disbursed daily, was
 assigned him by the king of Babylon, and he continued
 to enjoy it all his life up to the day that he died.

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -4610,9 +4610,10 @@ forsaken of man and beast,
 heard the voice of mirth and gladness, the voice of
 bridegroom and bride, the voice of those that say, as they
 bring their thank-offerings into the House of Jehovah,
-\q2 Give thanks to Jehovah of Hosts,
-\q2 For Jehovah is gracious,
-\q2 His kindness endureth for ever.
+\qm Give thanks to Jehovah of Hosts,
+\qm For Jehovah is gracious,
+\qm His kindness endureth for ever.
+\p
 For I will restore the fortunes of the land, saith
 Jehovah, as in the olden time.
 \v 12 Thus saith Jehovah of
@@ -5254,10 +5255,10 @@ the message revealed to me in a vision by Jehovah
 the palace of the king of Judah brought out to the chief
 officers of the king of Babylon, chanting the while this
 song:
-\q Thy most excellent friends have beguiled
-\q2 And prevailed over thee,
-\q Thy feet they have thrust in the mire,
-\q2 And thus sinking have left thee.
+\qm Thy most excellent friends have beguiled
+\qm2 And prevailed over thee,
+\qm Thy feet they have thrust in the mire,
+\qm2 And thus sinking have left thee.
 \p
 \v 23 All your wives and children they shall bring out to
 the Chaldeans, and you yourself shall not escape; you

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -56,13 +56,12 @@ Jerusalem were swept into exile.
 
 
 \ms2 The Reassuring Vision of the Almond Tree
-\q
+\p
 \v 11 This further message came to me from Jehovah:
-\q2 "What seest thou there, Jeremiah?" (said the Voice).
-\q
+"What seest thou there, Jeremiah?" (said the Voice).
 \v 12 "A branch of an almond tree," I answered. "Thou
-\q hast seen truly," said Jehovah," for I am watching
-\q over My purpose, to perform it."
+hast seen truly," said Jehovah," for I am watching
+over My purpose, to perform it."
 
 \ms2 The Vision of the Caldron of War
 
@@ -119,9 +118,9 @@ north."
 
 \p
 \v 1 There came to me this message from Jehovah:
-\q
+\p
 \v 2 Go and proclaim in the hearing of Jerusalem:
-\q Thus saith Jehovah:
+\p Thus saith Jehovah:
 \q I remember the love of thy youth–
 \q2 An affectionate bride wast thou–
 \q When thou followedst Me in the desert,
@@ -1223,7 +1222,7 @@ rather death than life, saith Jehovah of Hosts.
 
 
 \ms2 The National Refusal to Repent and the Coming Retribution
-\q
+\p
 \v 4 Thou shalt say to them, Thus saith Jehovah:
 \q Doth not one who has fallen rise up again,
 \q2 And one who hath wandered turn back again?
@@ -1434,7 +1433,8 @@ rather death than life, saith Jehovah of Hosts.
 \q2 To them and their fathers unknown;
 \q The sword I will send to pursue them,
 \q2 Until I have clean consumed them.
-\q
+\b
+\p
 \v 17 Thus saith Jehovah of Hosts:
 \q Now mark ye well and summon
 \q2 The women that chant in dirges;
@@ -1470,7 +1470,7 @@ rather death than life, saith Jehovah of Hosts.
 
 
 \ms2 The True Glory of a Man
-\q
+\p
 \v 23 Thus saith Jehovah:
 \q Let the wise man not boast of his wisdom,
 \q2 Let the strong man not boast of his strength;
@@ -1507,9 +1507,8 @@ household of Israel is uncircumcised in heart.
 
 
 \c 10
-\q
+\p
 \v 1 Listen, O household of Israel, to the word which Jehovah
-\q2
 hath spoken to you.
 \v 2 Thus saith Jehovah:
 \q Learn not the ways of the heathen,
@@ -2075,21 +2074,20 @@ shall restrain Me from destroying them.
 
 
 \s The Divine Answer
-\q
+\p
 \v 10 Touching this people Jehovah thus answered:
 \q Thus do they love to wander
 \q2 With unrestrained feet,
 \q2 But Jehovah cannot accept them:
 \q Their guilt He now calleth to mind,
 \q2 Their sins He will visit with chastisement.
-\q
+\p
 \v 11 And Jehovah said to me: Offer no prayer for the
-\q
 welfare of this people.
 \v 12 When they fast, I will be deaf
-\q to their cry; when they offer burnt-offerings and
-\q cereal offerings, I will not accept them. By sword,
-\q by famine, by pestilence, I will consume them.
+to their cry; when they offer burnt-offerings and
+cereal offerings, I will not accept them. By sword,
+by famine, by pestilence, I will consume them.
 
 
 \s The Prophet's Remonstrance
@@ -2175,7 +2173,7 @@ them.
 
 
 \c 15
-\q
+\p
 \v 1 Then Jehovah said to me:
 \q Though Moses and Samuel stood before Me,
 \q Yet no learning of heart could I have for this people;
@@ -2187,16 +2185,15 @@ them.
 \q2 To the sword, those doomed to the sword;
 \q To famine, those destined to famine,
 \q2 To exile, those destined to exile.
-\q
+\p
 \v 3 And I, saith Jehovah, will set over them four kinds
-\q (of destroyers) – the sword to slay, the dogs to tear,
-\q the birds of the air to devour, and the beasts of the
-\q
+(of destroyers) – the sword to slay, the dogs to tear,
+the birds of the air to devour, and the beasts of the
 earth to destroy;
 \v 4 and I will make them an object of
-\q Consternation to every kingdom in the world, in return
-\q for all the evil wrought in Jerusalem by Manasseh,
-\q the son of Hezekiah, king of Judah.
+consternation to every kingdom in the world, in return
+for all the evil wrought in Jerusalem by Manasseh,
+the son of Hezekiah, king of Judah.
 \q
 \v 5 O Jerusalem, who will then pity thee?
 \q2 Who will commiserate thee?
@@ -2270,7 +2267,7 @@ earth to destroy;
 
 
 \s The Divine Answer
-\q
+\p
 \v 19 Thus therefore saith Jehovah:
 \q If thou turn again, I will restore thee,
 \q2 And thou shalt be My servant.
@@ -2297,7 +2294,7 @@ earth to destroy;
 
 
 \c 16
-\q
+\p
 \v 1 There came to me this message from Jehovah:
 \q
 \v 2 Thou shalt not take thee a wife,
@@ -2613,6 +2610,7 @@ life and behaviour."
 is no hope of that: rather will we follow devices of our
 own and yield, every man of us, to the impulses of our
 wicked and stubborn hearts."
+\p
 \v 13 Thus therefore saith Jehovah:
 \q Ask any heathen man
 \q2 If he ever heard aught like this?
@@ -3622,8 +3620,8 @@ addressed the people assembled:
 king of Judah," they said, "Micah of Moresheth was
 prophesying; and this is what he said to all the people
 of Judah:
-Thus saith Jehovah of Hosts:
-Like a field shall Zion be ploughed,
+\p Thus saith Jehovah of Hosts:
+\q Like a field shall Zion be ploughed,
 \q2 And Jerusalem levelled to ruins;
 \q And the Temple Mount shall become
 \q2 Like a thickly wooded height.
@@ -5961,10 +5959,10 @@ Judah.
 \q2 And the earth is full of thy cry;
 \q For warrior stumbles on warrior,
 \q2 Both are fallen together.
-\q
+\p
 \v 13 The message of Jehovah to Jeremiah the prophet, that
-\q Nebuchadrezzar, king of Babylon, would come and
-\q smite the land of Egypt.
+Nebuchadrezzar, king of Babylon, would come and
+smite the land of Egypt.
 \q
 \v 14 Tell it Migdol,
 \q2 Publish it in Memphis:
@@ -6211,15 +6209,12 @@ Pharaoh smote Gaza.
 \q
 \v 20 "Moab is put to shame:
 \q2 She is broken; howl ye and cry."
-\q
+\p
 \v 21 Tell it by the Arnon that Moab is laid waste.
-\q2 Judgment is come upon the table-land – upon Holon,
-\q
+Judgment is come upon the table-land – upon Holon,
 Jahzah, and Mephaath,
 \v 22 upon Dibon, Nebo, and Beth-diblathaim,
-\q
 \v 23 upon Kiriathaim, Beth-gamul, and Beth-meon,
-\q
 \v 24 upon Keriyyoth and Bozrah, and all the cities
 of the land of Moab, far and near.
 \q
@@ -6331,7 +6326,8 @@ her?
 \q2 Thy daughters are led to captivity.
 \q Yet Moab I will restore.
 \q2 In the latter days, saith Jehovah.
-\q Thus far is the judgment upon Moab.
+\b
+\p Thus far is the judgment upon Moab.
 
 
 \ms2 Oracle on Ammon
@@ -6408,7 +6404,6 @@ her?
 deserve to drink the cup must drink it nevertheless,
 how canst thou expect to go utterly unpunished?
 Nay, verily, thou shalt no escape, but drink it thou
-\q
 shalt.
 \v 13 For I have most solemnly sworn, saith Jehovah,
 that Bozrah shall be a horror, a scorn, and a curse,
@@ -7139,7 +7134,7 @@ the prophet.
 \q To awake nevermore, saith the King,
 \q2 Whose name is Jehovah of Hosts.
 \b
-\q
+\p
 \v 58 Thus saith Jehovah of Hosts:
 \q Babylon's broad wall shall be razed to the ground,
 \q2 And her towering gates in the fire shall be burned:

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -3174,7 +3174,7 @@ and they shall dwell in their own land.
 \s The Character and Fate of the False Prophets
 
 
-\p
+\pc
 \v 9 Concerning the prophets.
 \q My heart within me is broken,
 \q2 My bones are all grown soft;
@@ -5905,9 +5905,9 @@ When I must destroy what I built,
 \v 1 The message concerning the nations which Jeremiah
 the prophet received from Jehovah.
 
-\p
+\pc
 \v 2 On Egypt.
-Concerning the army of Pharaoh Necho king of Egypt
+\p Concerning the army of Pharaoh Necho king of Egypt
 at Carchemish on the river Euphrates, where it was
 defeated by Nebuchadrezzar, king of Babylon, in the
 fourth year of Jehoiakim the son of Josiah, king of
@@ -6379,7 +6379,7 @@ her?
 
 
 \ms2 Oracle on Edom
-\q
+\pc
 \v 7 On Edom.
 \q Thus saith Jehovah of Hosts:
 \q2 Is wisdom no more in Teman?
@@ -7174,7 +7174,7 @@ of the Euphrates, with the words:
 sink, to rise no more, because of all the misery that I
 shall bring upon her.'"
 
-\p Here end the words of Jeremiah.
+\pc Here end the words of Jeremiah.
 
 
 

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -3350,7 +3350,6 @@ good, and the bad very bad, so bad that they cannot be
 eaten."
 \p
 \v 4 Thereupon this message came to me from Jehovah,
-\p
 \v 5 "Thus saith Jehovah the God of Israel: As with these
 good figs, so will I regard with favour the exiles of
 Judah, whom I have sent out of this place into the land
@@ -5755,6 +5754,7 @@ the streets of Jerusalem?
 remained unhumbled and unafraid. They have not
 lived in accordance with My law or with the statutes
 I set before you and your forefathers.
+\p
 \v 11 Therefore thus saith Jehovah of Hosts, the God of
 Israel: Mark this – I will set My face against you for
 Evil, to exterminate Judah utterly.

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -5280,15 +5280,9 @@ courtiers did all come to Jeremiah and question him;
 and the story he told them was in entire accordance
 with the king's instructions. So they said no more to
 him, for no part of the conversation had been heard.
-\v 28a Jeremiah accordingly remained in the guard-court
+\v 28 Jeremiah accordingly remained in the guard-court
 till the day Jerusalem was taken.
-
-
-\ms2 Provision made for Jeremiah's safety after the Capture of Jerusalem
-
-
-\p
-\v 28b When Jerusalem was taken, all the chief officers of
+\b
 
 \c 39
 
@@ -5303,10 +5297,12 @@ with all his forces against Jerusalem and laid siege to
 it.
 \v 2 On the ninth day of the fourth month of the
 eleventh year of Zedekiah a breach was made in the
-\v 3 the king of Babylon came and took their seats
+city.
+\v 3 All the chief officers of
+the king of Babylon came and took their seats
 in the middle gate – Nergalsharezer the Rab-mag,
 Nebushazban the Rab-saris, and all the rest of the
-city.
+officers of the king of Babylon.
 \v 4 On observing this, Zedekiah, king of Judah, and
 all the soldiers took to flight, leaving the city during the
 night by way of the royal garden, by the gate between
@@ -5340,7 +5336,11 @@ Nebuzaradan, the commander of the guard, and
 Nebuzaradan, the Rab-saris, and Nergalsharezer, the
 Rab-mag, and all the chief officers of the king of
 Babylon.
-Officers of the king of Babylon.
+
+
+\ms2 Provision made for Jeremiah's safety after the Capture of Jerusalem
+
+
 \v 14 They sent and had
 Jeremiah brought from the guard-court, and delivered
 him to Gedaliah, the son of Ahikam, the son of

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -2135,7 +2135,9 @@ earth to destroy;
 \q I will make My people childless,
 \q2 And destroy them because of their wickedness,
 \q
-\v 8c A destroyer I will bring
+\v 8 Their widows are more in number
+\q2 Than the sand of all the seas.
+\q A destroyer I will bring
 \q2 Upon mother and suckling at noon-day;
 \q I will bring of a sudden upon her
 \q2 Agitation and dismay.
@@ -2144,14 +2146,8 @@ earth to destroy;
 \q2 And she shall swoon away;
 \q Her sun shall go down in the day-time,
 \q2 Ashamed and abashed shall she be.
-\q
-\v 8a Their widows are more in number
-\q2
-\v b Than the sand of all the seas,
-\q
-\v 9e And the rest of them I will deliver
-\q2
-\v f To the sword in the face of their foes.
+\q And the rest of them I will deliver
+\q2 To the sword in the face of their foes.
 
 
 \s The Prophet's Passionate Lament

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -6644,6 +6644,7 @@ shall bring upon her.'"
 came to the throne, reigned for eleven years in Jerusalem.
 His mother's name was Hamutal, a daughter of
 \v 2 Jeremiah of Libnah. His actions were offensive to
+Jehovah, exactly as Jehoiakim's had been, and
 \v 3 Jehovah was so angry with Jerusalem and Judah that
 He cast them out of His sight; and Zedekiah revolted
 against the king of Babylon.

--- a/source/24-Jeremiah.usfm.db
+++ b/source/24-Jeremiah.usfm.db
@@ -37,6 +37,7 @@ Jerusalem were swept into exile.
 \q2 I have no skill of speech, I am only a child."
 \p
 \v 7 Then Jehovah made answer to me:
+\b
 \q "Do not plead thou art still but a child,
 \q Thou must go wheresoever I send thee,
 \q2 And say whatsoever I bid thee.
@@ -147,6 +148,7 @@ north."
 \q
 \v 6 And never sought after Jehovah,
 \q2 Who brought them up out of Egypt,
+\b
 \q And led them through the desert,
 \q2 A land of steppes and pits,
 \q A land of drought and gloom,
@@ -167,6 +169,7 @@ north."
 \q
 \v 9 I must therefore contend with you still,
 \q2 And with your children's children.
+\b
 \q
 \v 10 Pass across to the isles of Cyprus,
 \q2 Or send afar unto Kedar;
@@ -177,6 +180,7 @@ north."
 \q2 Though they be no gods at all?
 \q But My people hath exchanged
 \q2 Their Glory for useless idols.
+\b
 \q
 \v 12 Be appaled at this, ye heavens,
 \q2 And shudder exceedingly.
@@ -206,6 +210,7 @@ north."
 \q
 \v 17 And is this not come upon thee
 \q2 Through forsaking Jehovah thy God?
+\b
 \q
 \v 18 Now why dost thou wander to Egypt
 \q2 And drink the waters of Nile?
@@ -239,6 +244,7 @@ north."
 \q2 And take thee abundance of soap,
 \q Yet the Lord, as He seeth thy guilt,
 \q2 Shall declare it of deepest dye.
+\b
 \q
 \v 23 How canst thou say, "All stainless am I,
 \q2 I have not gone after the Baals"?
@@ -274,6 +280,7 @@ north."
 \q2 Their backs and not their faces;
 \q Yet in time of trouble they say,
 \q2 "O rise Thou up and save us."
+\b
 \q
 \v 28 But where are the gods thou didst make thee?
 \q2 Let them arise, if they
@@ -285,6 +292,7 @@ north."
 \q2 For wicked ye are, every man of you;
 \q Rebels are ye, saith Jehovah–
 \q2 Rebels against Me, each man of you.
+\b
 \q
 \v 30 In vain have I smitten your children,
 \q2 They would not receive correction;
@@ -297,6 +305,7 @@ north."
 \q2 A dark and gloomy land?
 \q Why then do ye say, "We are free,
 \q2 We will come unto Thee nevermore?"
+\b
 \q
 \v 32 Can a maid forget her ornaments,
 \q2 Or a bride forget her sash?
@@ -307,6 +316,7 @@ north."
 \q2 Thou trippest along thy way!
 \q Small wonder thy deeds are so vile,
 \q2 And thy way hath been all polluted.
+\b
 \q
 \v 34 Yea, blood was found in thy skirts–
 \q2 Of the lives of the innocent poor–
@@ -317,6 +327,7 @@ north."
 \q2 Surely His anger is over."
 \q But see, I will enter with thee into judgment,
 \q2 Because thou dost claim to be sinless.
+\b
 \q
 \v 36 Why runnest thou hither and thither
 \q2 With so frivolous a heart?
@@ -340,6 +351,7 @@ north."
 \q2 Can she ever again be his?
 \q Is such a woman as she
 \q2 Not altogether polluted?
+\b
 \q But thou hast played the harlot
 \q2 With many and many a lover;
 \q And canst thou dare to dream
@@ -354,6 +366,7 @@ north."
 \q
 \v 3 And through thy many lovers
 \q2 Thou hast let thyself be snared.
+\b
 \q Thou hast a harlot's forhead,
 \q2 Refusing to be abashed,
 \q
@@ -445,6 +458,7 @@ your forefathers for an inheritance.
 \q
 \v 20 But ye have been false unto Me,
 \q2 As a woman is false to her lover.
+\b
 \q
 \v 21 Hark! weeping is heard on the heights–
 \q2 It is suppliant Israel crying,
@@ -454,6 +468,7 @@ your forefathers for an inheritance.
 \v 22 "Return, ye backsliding I will heal."
 \q "Behold, we are come unto Thee,
 \q2 For Thou art Jehovah our God.
+\b
 \q
 \v 23 The hills are but a delusion,
 \q2 And the orgies upon the mountains;
@@ -464,6 +479,7 @@ your forefathers for an inheritance.
 \q2 Of our fathers from our youth–
 \q Their sheep and their oxen together,
 \q2 Their sons and their daughters together
+\b
 \q
 \v 25 We would lay us down in our shame,
 \q2 All covered with confusion;
@@ -476,6 +492,7 @@ your forefathers for an inheritance.
 
 
 \c 4
+\b
 \q
 \v 1 "O Israel, if thou wilt return," saith Jehovah,
 \q2 If thou but return unto Me,
@@ -486,6 +503,7 @@ your forefathers for an inheritance.
 \q2 Thou swear, 'As Jehovah liveth,'
 \q Then nations shall pray for a blessing like thine,
 \q2 And in thee shall they make their boast.
+\b
 \q
 \v 3 For thus saith Jehovah to the citizens of Judah,
 \q2 And to them that dwell in Jerusalem:
@@ -515,6 +533,7 @@ your forefathers for an inheritance.
 \q2 Flee ye for safety and stay out;
 \q For disaster and fell destruction
 \q2 I soon will bring out the north.
+\b
 \q
 \v 7 A lion hath gone from his thicket;
 \q2 The Devastator of nations
@@ -525,6 +544,7 @@ your forefathers for an inheritance.
 \q2 Make ye lament and wail;
 \q2 For the fierce glowing wrath of Jehovah
 \q2 Doth turn not away nor leave us.
+\b
 \q
 \v 9 The heart of the king and the princes
 \q2 Shall fail int that day, saith Jehovah;
@@ -536,6 +556,7 @@ your forefathers for an inheritance.
 \q2 This people and Jerusalem,
 \q Assuring us all would be well,
 \q2 While the doth pierce to the soul."
+\b
 \q
 \v 11 This message shall then be declared
 \q2 To Jerusalem and this people:
@@ -545,6 +566,7 @@ your forefathers for an inheritance.
 \q
 \v 12 Too keen is the blast for that.
 \q2 So now I will utter My judgment upon them.
+\b
 \q
 \v 13 Behold! he mounteth as clouds,
 \q2 His chariots are like to the whirlwind,
@@ -555,6 +577,7 @@ your forefathers for an inheritance.
 \q2 Jerusalem, that thou mayest be saved:
 \q How long wilt thou harbour within thee
 \q2 Thine evil imaginations?
+\b
 \q
 \v 15 Hark! a message from Dan,
 \q2 From Mount Ephraim, evil tidings;
@@ -565,6 +588,7 @@ your forefathers for an inheritance.
 \q2 From a land that is far away,
 \q They are raising loud their roar
 \q2 Against the cities of Judah.
+\b
 \q
 \v 17 Lying in wait in the fields,
 \q2 They beset her round and round–
@@ -593,6 +617,7 @@ your forefathers for an inheritance.
 \q2 For all the land is laid waste;
 \q My tents of a sudden are spoiled,
 \q2 Yea, all in a moment my curtains.
+\b
 \q
 \v 21 How long must I look on the standard
 \q2 And hear the sound of the trumpet?
@@ -603,6 +628,7 @@ your forefathers for an inheritance.
 \q2 Devoid of understanding:
 \q Wise are they to do evil,
 \q2 But they know not how to do good.
+\b
 \q
 \v 23 I looked at the earth, and behold! it was empty.
 \q2 I looked at the heavens, and their light was gone,
@@ -629,6 +655,7 @@ your forefathers for an inheritance.
 \q2 And the heavens above be black;
 \q For I have not repented My words,
 \q2 And I will not turn back from My purpose.
+\b
 \q
 \v 29 At the noise of the horsemen and bowmen
 \q2 The whole land taketh to flight;
@@ -636,6 +663,7 @@ your forefathers for an inheritance.
 \q2 They climb up on to the rocks.
 \q Abandoned is very city,
 \q2 And not a man dwelleth therein.
+\b
 \q
 \v 30 Why, then, dost thou robe thee in scarlet,
 \q2 And deck thee with jewels of gold,
@@ -643,6 +671,7 @@ your forefathers for an inheritance.
 \q2 In vain dost thou make thyself fair.
 \q They that doted on thee despite thee;
 \q2 It is thy life that they seek.
+\b
 \q
 \v 31 For a cry have I heard as of woman in travail,
 \q2 A scream as of one bringing forth her first child.
@@ -665,6 +694,7 @@ your forefathers for an inheritance.
 \q2 And seeketh after truth;
 \q Then I – Jehovah declareth–
 \q2 Will grant her My forgiveness.
+\b
 \q
 \v 2 But even when they say, "By Jehovah,"
 \q2 They are ready to swear to a lie.
@@ -680,11 +710,13 @@ your forefathers for an inheritance.
 \q2 The people without understanding,
 \q Who know not the way of Jehovah,
 \q2 The ordinance of their God.
+\b
 \q
 \v 5 I will get me unto the great men,
 \q2 And unto them will I speak;
 \q For they know the way of Jehovah,
 \q2 The ordinance of their God."
+\b
 \q But these very men have all broken the yoke,
 \q2 And snapped the bonds asunder.
 \q
@@ -695,6 +727,7 @@ your forefathers for an inheritance.
 \q2 And rend all that issue therefrom.
 \q For many are their their transgressions,
 \q2 And far they have turned away.
+\b
 \q
 \v 7 How then for this can I pardon thee?
 \q2 Thy children have forsaken Me,
@@ -702,6 +735,7 @@ your forefathers for an inheritance.
 \q2 And, when to the full I had fed them,
 \q Adultery they committed,
 \q2 They lodge in the houses of harlots.
+\b
 \q
 \v 8 Well fed stallions were they,
 \q2 Neighing each for his neighbour's wife.
@@ -726,6 +760,7 @@ your forefathers for an inheritance.
 \q2 And said, "He will never do it;
 \q No evil shall come upon us,
 \q2 We shall see neither sword nor famine.
+\b
 \q
 \v 13 The prophets are only wind,
 \q2 The word is not in them:
@@ -736,6 +771,7 @@ your forefathers for an inheritance.
 \q2 I will make like a flaming fire,
 \q And this people shall be as the fuel,
 \q2 And it shall clean devour them.
+\b
 \q
 \v 15 Behold, I am bringing against you,
 \q2 O household of Israel, saith Jehovah,
@@ -757,6 +793,7 @@ your forefathers for an inheritance.
 \q
 \v 18 But in those days, saith Jehovah,
 \q2 I will not make a clean end of you.
+\b
 \q
 \v 19 And in time to come, when ye say to Me,
 \q2 "Why hath Jehovah our God
@@ -787,6 +824,7 @@ your forefathers for an inheritance.
 \q
 \v 23 But these people are stubborn, defiant in heart,
 \q2 They are turned aside and gone.
+\b
 \q
 \v 24 For they do not say in their hearts,
 \q2 "Let us fear Jehovah, our God,
@@ -809,6 +847,7 @@ your forefathers for an inheritance.
 \q2 They run riot in deeds of wickedness.
 \q They defend not the rights of the orphan,
 \q2 Nor champion the cause of the needy.
+\b
 \q
 \v 29 And things like these, saith Jehovah,
 \q2 Am I to leave unpunished?
@@ -843,6 +882,7 @@ your forefathers for an inheritance.
 \q2 They and their flocks together;
 \q They shall pitch their tents around about her,
 \q2 And graze on her, each where he camps.
+\b
 \q
 \v 4 "Prepare ye war against her;
 \q2 Up! let us storm her at noon-day."
@@ -857,6 +897,7 @@ your forefathers for an inheritance.
 \q2 And cast up a mound against her.
 \q Woe to thee, City of Falsehood,
 \q2 Within thee is nothing but tyranny.
+\b
 \q
 \v 7 As a well keepeth fresh her waters,
 \q2 She keepeth her wickedness fresh;
@@ -867,6 +908,7 @@ your forefathers for an inheritance.
 \q2 Lest My soul from thee be severed,
 \q Lest I make thee a desolation,
 \q2 An uninhabited land.
+\b
 \q
 \v 9 Thus saith Jehovah of Hosts;
 \q "Glean like a vine full thoroughly
@@ -907,6 +949,7 @@ your forefathers for an inheritance.
 \q2 As though it were but slight;
 \q2 "It is well, it is well," they say,
 \q2 "When it is anything but well."
+\b
 \q
 \v 15 Are they at all abashed
 \q2 At their deeds abominable?
@@ -915,6 +958,7 @@ your forefathers for an inheritance.
 \q They shall therefore fall with the fallen;
 \q2 In the hour of their visitation
 \q2 They shall stumble, saith Jehovah.
+\b
 \q
 \v 16 Thus did Jehovah say:
 \q Stand in the ways and see,
@@ -927,6 +971,7 @@ your forefathers for an inheritance.
 \v 17 And over you I set watchmen.
 \q2 Saying "Hark for the sound of the trumpet."
 \q2 But they said, "We refuse to hearken."
+\b
 \q
 \v 18 Wherefore hearken, ye nations, and hear, O earth,
 \q2 Take knowledge of that which is coming.
@@ -941,6 +986,7 @@ your forefathers for an inheritance.
 \q2 And sweet cane from a distant land?
 \q I accept not your burnt-offerings,
 \q2 Your sacrifice pleaseth Me not.
+\b
 \q
 \v 21 Therefore, thus saith Jehovah: Behold,
 \q2 I will set on the way of this people
@@ -948,6 +994,7 @@ your forefathers for an inheritance.
 \q2 And over them stumble they shall,
 \q Fathers and sons together–
 \q2 And neighbour and friend shall perish.
+\b
 \q
 \v 22 Thus saith Jehovah, Behold!
 \q2 A people doth come from the north land,
@@ -960,6 +1007,7 @@ your forefathers for an inheritance.
 \q2 And they ride upon horses and chariots,
 \q Arrayed, like one man, for the battle,
 \q2 Against thee, O daughter of Zion.
+\b
 \q
 \v 24 The rumour thereof we have heard,
 \q2 And all unnerved are we:
@@ -970,6 +1018,7 @@ your forefathers for an inheritance.
 \q2 Go not abroad on the highway;
 \q For there is the sword of the enemy–
 \q2 Terror on every side.
+\b
 \q
 \v 26 O daughter of My people,
 \q Gird thee about with sackcloth
@@ -990,6 +1039,7 @@ your forefathers for an inheritance.
 \q2 They slander as they go;
 \q They are all of them brass and iron,
 \q2 They are all of them corrupt.
+\b
 \q
 \v 29 Fiercely the bellows blow,
 \q2 The lead is consumed by the fire;
@@ -1185,6 +1235,7 @@ rather death than life, saith Jehovah of Hosts.
 \q
 \v 6 I have listened with ear intent–
 \q2 And their words are utterly false.
+\b
 \q Not a man repents of his wickedness
 \q2 Or thinks upon what he has done:
 \q But each rushes on in his course
@@ -1196,6 +1247,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 Observe the time of their coming:
 \q But the ordinance of Jehovah
 \q2 My people doth not know.
+\b
 \q
 \v 8 How can ye say, "We are wise,
 \q2 And with us is the law of Jehovah"?
@@ -1209,6 +1261,7 @@ rather death than life, saith Jehovah of Hosts.
 \q
 \v 10 So their wives I will give unto others,
 \q2 To conquerors their fields.
+\b
 \q For, great and small alike,
 \q2 They are all of them greedy of gain;
 \q Prophet and priest alike–
@@ -1218,6 +1271,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 As though it were but slight;
 \q2 "It is well, it is well," they say,
 \q2 "When it is anything but well."
+\b
 \q
 \v 12 Are they at all abashed
 \q2 At their deeds abominable?
@@ -1226,6 +1280,7 @@ rather death than life, saith Jehovah of Hosts.
 \q They shall therefore fall with the fallen;
 \q2 In the hour of their visitation
 \q2 They shall stumble, saith Jehovah.
+\b
 \q
 \v 13 When I, saith Jehovah, would gather their fruit,
 \q2 There is not a grape on the vine;
@@ -1242,6 +1297,7 @@ rather death than life, saith Jehovah of Hosts.
 \q
 \v 15 We wait for peace, but no good cometh;
 \q2 For a season of healing, but lo! dismay."
+\b
 \q
 \v 16 From Dan is heard the snort of his steeds,
 \q At the sound of his stallions neighing
@@ -1269,6 +1325,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 Is not her King therein?"
 \q "With their images why have they vexed Me–
 \q2 With futile foreign gods?"
+\b
 \q
 \v 20 "The harvest is past, the summer is ended,
 \q2 And all unsaved are we."
@@ -1282,6 +1339,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 Is there no physician there?
 \q Why cometh then no healing
 \q2 To the daughter of my people?
+\b
 
 
 
@@ -1296,6 +1354,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 A spot such as travellers lodge in;
 \q For then would I leave my people,
 \q2 Yea, from them I would go;
+\b
 \q For they be all adulterers,
 \q2 A company of traitors,
 \q2 That bend their tongue like a bow.
@@ -1304,6 +1363,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 That has mastery in the land;
 \q For they pass from evil to evil,
 \q2 And they know not Me, saith Jehovah.
+\b
 \q
 \v 4 Let each man beware of his neighbour,
 \q2 And trust not any brother:
@@ -1314,6 +1374,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 The truth they will not speak;
 \q They have taught their tongue to lie,
 \q2 They behave like knaves and fools.
+\b
 \q
 \v 6 Oppression upon oppression,
 \q2 Deceit upon deceit:
@@ -1328,11 +1389,13 @@ rather death than life, saith Jehovah of Hosts.
 \q2 The words of their mouth are deceit;
 \q They speak their neighbour fair,
 \q2 But at heart they are laying a trap for him.
+\b
 \q
 \v 9 And crimes like these, saith Jehovah,
 \q2 Am I to leave unpunished?
 \q Shall not My soul be avenged
 \q2 On a nation such as this?
+\b
 \q
 \v 10 Lift a lament for the mountains,
 \q2 A dirge for the wilderness pastures;
@@ -1340,6 +1403,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 No lowing of cattle they hear:
 \q The birds of the air and the beasts
 \q2 Are fled away and gone.
+\b
 \q
 \v 11 I will make of Jerusalem ruins,
 \q2 A place for jackals to haunt;
@@ -1350,6 +1414,7 @@ rather death than life, saith Jehovah of Hosts.
 \q2 Himself hath communed with and charged
 \q To declare why the land us a ruin,
 \q2 Laid waste like the untravelled wilderness?
+\b
 \q
 \v 13 And Jehovah said unto me:
 \q Because they forsook My law
@@ -1385,6 +1450,7 @@ rather death than life, saith Jehovah of Hosts.
 \q We are put to utter shame,
 \q2 Because we have left the land,
 \q2 And our homes are hurled to the ground."
+\b
 \q
 \v 20 Hear then, ye women, the word of Jehovah,
 \q2 Received with your ears the word of His mouth,
@@ -1466,6 +1532,7 @@ hath spoken to you.
 \q Be not afraid of them, then,
 \q2 For they have it not in their power
 \q2 To do either good or harm.
+\b
 \q
 \v 6 There is none like Thee, O Jehovah;
 \q2 Thou art great, and great is Thy name in might.
@@ -1484,6 +1551,7 @@ hath spoken to you.
 \q2 And wrought by the craftsman and goldsmith,
 \q And robed in blue and in purple–
 \q2 The work of skilled men are they all–
+\b
 \q
 \v 10 But Jehovah is God indeed,
 \q2 A living God, and a King everlasting;
@@ -1493,6 +1561,7 @@ hath spoken to you.
 \v 12 He created the earth by His power,
 \q2 He established the world by His wisdom,
 \q2 He stretched out the heavens by His skill.
+\b
 \q
 \v 13 When He uttereth His voice,
 \q2 The waters roar in the heavens,
@@ -1500,6 +1569,7 @@ hath spoken to you.
 \q2 From the uttermost ends of the earth.
 \q Lightnings He made for the rain,
 \q2 And the wind He brings out of His storehouses.
+\b
 \q
 \v 14 How foolish is man with his knowledge!
 \q2 The goldsmith is shamed by his image;
@@ -1521,6 +1591,7 @@ hath spoken to you.
 \q2 The inhabitants of the land,
 \q And bring them into such straits
 \q2 That they shall melt for fear.
+\b
 \q
 \v 19 Ah! woe is me! I am broken,
 \q2 And smitten very sore,
@@ -1532,6 +1603,7 @@ hath spoken to you.
 \q2 My flock is vanished clean.
 \q There is none to stretch my tent,
 \q2 Or to hang up my curtains more.
+\b
 \q
 \v 21 For the shepherds are foolish grown,
 \q2 And nothing they care for Jehovah;
@@ -1775,6 +1847,7 @@ indulged, by burning sacrifice to the Baal."
 \q2 Their labour hath profited nothing;
 \q Their harvest shall bring them to shame,
 \q2 Because of Jehovah's hot anger.
+\b
 \q
 \v 14 This is the word of Jehovah,
 \q2 To all Mine evil neighbours
@@ -1913,6 +1986,7 @@ shall restrain Me from destroying them.
 \q2 To approach thee as lovers?
 \q Shall anguish not clutch at thee hard
 \q2 As of woman in travail?
+\b
 \q
 \v 22 But if in thy heart thou shouldst say,
 \q2 "Why is this come upon me?"
@@ -1927,6 +2001,7 @@ shall restrain Me from destroying them.
 \q
 \v 24 And so to the winds of the desert
 \q2 Like stubble that flies I will scatter them.
+\b
 \q
 \v 25 This is thy lot, this the portion
 \q2 I measure to thee, saith Jehovah;
@@ -2068,6 +2143,7 @@ them.
 \q2 Lo, there lie the victims of famine:
 \q Yea, prophet and priest alike,
 \q2 All witless, lie crouched on the ground,
+\b
 \q
 \v 19 Hast Thou utterly cast away Judah?
 \q2 Is Zion grown loathsome to Thee?
@@ -2075,6 +2151,7 @@ them.
 \q2 That we can find no healing?
 \q We look for peace, but no good cometh:
 \q2 For a season of healing, but lo! dismay.
+\b
 \q
 \v 20 We acknowledge, Jehovah, our wickedness,
 \q2 The guilt of our fathers also;
@@ -2083,6 +2160,7 @@ them.
 \v 21 For Thy name's sake, O spurn us not,
 \q2 O shame not Thy glorious throne:
 \q2 O remember and break out Thy covenant with us.
+\b
 \q
 \v 22 Of the worthless gods of the heathen
 \q2 Is there one that can bring down rain?
@@ -2141,6 +2219,7 @@ earth to destroy;
 \q2 Upon mother and suckling at noon-day;
 \q I will bring of a sudden upon her
 \q2 Agitation and dismay.
+\b
 \q
 \v 9 The mother of seven shall languish,
 \q2 And she shall swoon away;
@@ -2164,6 +2243,7 @@ earth to destroy;
 \q
 \v 12 Is the arm in my shoulder of iron?
 \q2 Or is my brow of brass?
+\b
 \q
 \v 15 O Jehovah, remember and visit me,
 \q2 Avenge me of my tormentors;
@@ -2176,6 +2256,7 @@ earth to destroy;
 \q2 The very joy of my heart;
 \q For I have been called by Thy name,
 \q2 O Jehovah, Thou God of Hosts.
+\b
 \q
 \v 17 No happy seat was mine
 \q2 At gatherings of the merry;
@@ -2247,6 +2328,7 @@ earth to destroy;
 \q2 And raise for them no wailing;
 \q Because from this (My) people
 \q2 I have taken away My peace.
+\b
 \q
 \v 6 Both great and small in this land shall die,
 \q2 They shall be unburied, unmourned;
@@ -2257,6 +2339,7 @@ earth to destroy;
 \q2 To comfort them for the dead;
 \q Nor shall cup of consolation
 \q2 Be given for father or mother.
+\b
 \q
 \v 8 Do not enter the house of feasting,
 \q2 To sit with them, eating and drinking.
@@ -2305,6 +2388,7 @@ other gods; for no favour shall ye have from Me."
 \v 17 For Mine eyes are all their ways,
 \q2 From My face they are not concealed,
 \q2 And their guilt is not hid from Mine eyes.
+\b
 \q
 \v 18 I will therefore requite them double
 \q2 For all their guilt and sin,
@@ -2391,6 +2475,7 @@ other gods; for no favour shall ye have from Me."
 \q2 And Tester of thoughts am I,
 \q To give each what his doings have earned,
 \q2 To let each reap the fruit of his deeds."
+\b
 \q
 \v 11 Like a patridge that sitteth on eggs
 \q2 That it hath not laid,
@@ -2408,6 +2493,7 @@ other gods; for no favour shall ye have from Me."
 \q2 In the land shall be put to confusion;
 \q Because they have forsaken
 \q2 The Fountain of Living Water.
+\b
 \q
 \v 14 "Heal me, Jehovah, and I shall be healed;
 \q2 Save me, and I shall be saved indeed:
@@ -2542,6 +2628,7 @@ wicked and stubborn hearts."
 \q2 Ordained for them of old,
 \q And turned into bypaths
 \q2 That never were truly laid.
+\b
 \q
 \v 16 So their land shall be made a horror–
 \q2 An everlasting scorn.
@@ -2733,6 +2820,7 @@ and all the friends to whom thou hast prophesied lies."
 \q
 \v 8 Every word that I utter is laughed at;
 \q2 "Wronged" and "despoiled" must I cry.
+\b
 \q For to me is the word of Jehovah
 \q2 An endless reproach and derision.
 \q
@@ -2742,6 +2830,7 @@ and all the friends to whom thou hast prophesied lies."
 \q2 Shut up within my bones;
 \q I am weary of enduring,
 \q2 and I can bear it no more.
+\b
 \q
 \v 10 For I hear their many whispers–
 \q2 A terror on every side–
@@ -2859,6 +2948,7 @@ In the morning give righteous judgment,
 \q Lest My fury break forth like fire
 \q2 And blaze unquenchably,
 \q2 Because of your evil doings.
+\b
 \q
 \v 13 Behold, I am against thee,
 \q2 Thou denizen of the vale
@@ -3097,6 +3187,7 @@ and they shall dwell in their own land.
 \v 10 For the land is full of adulterers
 \q2 Who run an evil course,
 \q2 And whose might is not of right.
+\b
 \q
 \v 11 For prophet and priest are profane:
 \q2 Their wickedness I have witnessed
@@ -3107,6 +3198,7 @@ and they shall dwell in their own land.
 \q2 Whereon they are thrust till they fall:
 \q For I will bring evil upon them–
 \q2 The year of their visitation.
+\b
 \q
 \v 13 In Samaria's prophets I witnessed
 \q2 Behaviour that was revolting;
@@ -3141,6 +3233,7 @@ and they shall dwell in their own land.
 \q2 That all with them shall be well.
 \q They assure those who follow their own stubborn hearts
 \q2 That no evil shall come upon them.
+\b
 \q
 \v 18 But which of them ever hath stood and looked on
 \q2 In the council of Jehovah?
@@ -3168,6 +3261,7 @@ and they shall dwell in their own land.
 \v 25 I have heard what the prophets say,
 \q2 That prophesy lies in My name;
 \q2 "I have dreamed, I have dreamed, I have dreamed."
+\b
 \q
 \v 26 Will the heart of the prophets not turn
 \q2 That prophesy lies, and that prophesy
@@ -3178,6 +3272,7 @@ and they shall dwell in their own land.
 \q2 By the dreams that they tell one another,
 \q As erst by the Baal My name
 \q2 Was driven from the mind of their fathers?
+\b
 \q
 \v 28 The prophet that hath a dream–
 \q2 Let him declare his dream:
@@ -3819,6 +3914,7 @@ refused to listen, saith Jehovah.
 \v 20 See, then, that ye listen to
 Jehovah's message, all of you exiles whom I have sent from
 Jerusalem to Babylon.
+\b
 in Babylon.
 \v 21 Well, thus saith Jehovah of Hosts, the
 God of Israel, concerning Ahab the son of Kolaiah and
@@ -3906,6 +4002,7 @@ concerning Israel and Judah.
 \q2 Every man with his hands on his loins?
 \q And what mean all these faces
 \q2 Turned to a deathly pallor?
+\b
 \q
 \v 7 Alas! for great is this day,
 \q2 No day is like unto it;
@@ -3920,6 +4017,7 @@ concerning Israel and Judah.
 \v 9 But Jehovah their God they shall serve.
 \q2 And David also, their king,
 \q2 Whom I will raise up unto them.
+\b
 \q
 \v 10 So fear thou not, O Jacob My servant,
 \q2 O Israel, be not dismayed, saith Jehovah.
@@ -3952,6 +4050,7 @@ concerning Israel and Judah.
 \q2 With chastisement unpitying,
 \q Because of thy manifold guilt
 \q2 And thy sins that are grown so mighty.
+\b
 \q
 \v 15 Why criest thou over thy wound,
 \q2 That thy pain is past all healing?
@@ -3983,6 +4082,7 @@ concerning Israel and Judah.
 \q2 And the voices of them that make merry;
 \q I will add to their numbers till many they be,
 \q2 I will crown them with glory, and they shall be honoured.
+\b
 \q
 \v 20 Their children shall be as in days of old,
 \q2 And their sacred assembly safe under My care;
@@ -4032,6 +4132,7 @@ concerning Israel and Judah.
 \v 3 From afar will Jehovah appear to him.
 \q I have loved thee with love everlasting.
 \q2 And so I with kindness have drawn thee.
+\b
 \q
 \v 4 Once more, O virgin of Israel,
 \q2 I will build thee up securely:
@@ -4046,6 +4147,7 @@ concerning Israel and Judah.
 \q2 On Ephraim's highlands shall cry,
 \q2 "Arise, let us pilgrim to Zion,
 \q2 Where dwelleth Jehovah our God."
+\b
 \q
 \v 7 For thus saith Jehovah to Jacob,
 \q2 Ring out a cry of joy;
@@ -4053,6 +4155,7 @@ concerning Israel and Judah.
 \q2 Publish, and praise, and say,
 \q "Jehovah hath saved His people,
 \q2 The remnant of Israel."
+\b
 \q
 \v 8 Behold, from the north land I bring them,
 \q2 And out of earth's uttermost parts I will gather them–
@@ -4074,6 +4177,7 @@ concerning Israel and Judah.
 \q
 \v 11 For Jehovah hath ransomed Jacob,
 \q2 And redeemed him from hands that were stronger than his.
+\b
 \q
 \v 12 They shall come, they shall sing on the heights of Zion,
 \q2 All radiant with joy at the gifts of Jehovah–
@@ -4081,6 +4185,7 @@ concerning Israel and Judah.
 \q2 And the young of the flock and the herd;
 \q Their soul like a well-watered garden shall be,
 \q2 And they shall pine no more.
+\b
 \q
 \v 13 Then the maids shall rejoice in the dance,
 \q2 And the young and the old shall be merry;
@@ -4122,6 +4227,7 @@ concerning Israel and Judah.
 \q2 Chastened, I smote on my beasts.
 \q Put to shame and confusion am I,
 \q2 For I bear the reproach of my youth."
+\b
 \q
 \v 20 Is not Ephraim my dear, dear son?
 \q2 Is he not a darling child?
@@ -4129,12 +4235,14 @@ concerning Israel and Judah.
 \q2 And My mind keeps resting upon him.
 \q So My heart for him doth yearn,
 \q2 And pity him I must.
+\b
 \q
 \v 21 Set way-marks, and make thee guide-posts;
 \q Bethink thee of the highway,;
 \q2 The road by which thou didst travel.
 \q Return, O virgin of Israel,
 \q2 Return to these thy cities.
+\b
 \q
 \v 22 How long, O backsliding daughter,
 \q2 Wilt thou remain irresolute?
@@ -4162,6 +4270,7 @@ concerning Israel and Judah.
 \q
 \v 26 Thereupon I awoke and gazed,
 \q2 For my sleep had been sweet unto me.
+\b
 \q
 \v 27 Behold, saith Jehovah, the days are coming,
 \q2 When I will sow the households of Israel and Judah
@@ -4199,6 +4308,7 @@ concerning Israel and Judah.
 \q2 And write it upon their heart,
 \q And I will be their God,
 \q3 And they shall be My people.
+\b
 \q
 \v 34 No more need any teach
 \q2 His fellow to know Jehovah;
@@ -5809,6 +5919,7 @@ Judah.
 \v 4b Harness the steeds, mount the chargers,
 \q2 Stand forth in your helmets.
 \q2 Polish your spears, don your breastplates.
+\b
 \q
 \v 5 Why are they turned in dismay–
 \q2 Their warriors crushed,
@@ -5832,6 +5943,7 @@ Judah.
 \q2 And forth, ye warriors, march–
 \q Cush and Put, that handle the shield,
 \q2 And ye Ludim, that bend the bow."
+\b
 \q
 \v 10 But that day is the Lord Jehovah's–
 \q2 A day of revenge on His foes,
@@ -5868,6 +5980,7 @@ Judah.
 \q "Let us flee from the murderous sword,
 \q2 Let us rise and go back to our people,
 \q2 To the land wherein we were born."
+\b
 \q
 \v 17 Call Pharaoh of Egypt "Blusterer,
 \q2 Who hath let the hour go by."
@@ -5881,6 +5994,7 @@ Judah.
 \q2 Prepare thee to go into exile;
 \q For Noph is become like a desert,
 \q2 An uninhabited waste.
+\b
 \q
 \v 20 A graceful heifer is Egypt,
 \q2 But a wasp from the north hath assailed her.
@@ -5907,6 +6021,7 @@ Judah.
 \q
 \v 22c Against her they come with axes,
 \q2 Like men that hew down trees,
+\b
 \q
 \v 23a "Fell, saith Jehovah, "her forest,
 \q2
@@ -5926,6 +6041,7 @@ Judah.
 \q2 King of Babylon, and his servants.
 \q But afterwards she shall be peopled
 \q2 As in days of old, saith Jehovah.
+\b
 \q
 \v 27 So fear them not, O Jacob My Servant;
 \q2 O Israel, be not dismayed, saith Jehovah.
@@ -5965,6 +6081,7 @@ Pharaoh smote Gaza.
 \q2 At the rush of his chariots, the roar of his wheels,
 \q The father shall not look behind for the children;
 \q2 For all unnerved shall they be–
+\b
 \q
 \v 4 Because of the day of destruction
 \q2 That cometh on all the Philistines,
@@ -5977,6 +6094,7 @@ Pharaoh smote Gaza.
 \q2 Ashkelon is destroyed.
 \q O ye that are left of the Anakim,
 \q2 How long must ye gash yourselves yet?
+\b
 \q
 \v 6 "Ah! Sword of Jehovah!
 \q2 How long will it be ere thou rest?
@@ -6005,6 +6123,7 @@ Pharaoh smote Gaza.
 \q "Come, let us blot out the nation;
 \q Thou, Madmen, shalt be silenced,
 \q2 The sword shall follow thee hard."
+\b
 \q
 \v 3 Hark! a shriek from Horonaim–
 \q2 Havoc and fell destruction.
@@ -6019,6 +6138,7 @@ Pharaoh smote Gaza.
 \q
 \v 6 Fly, escape for your lives,
 \q2 Though like bare desert shrub shall ye be.
+\b
 \q
 \v 7 Thou hast trusted in thy strongholds,
 \q2 And therefore art thou taken:
@@ -6030,6 +6150,7 @@ Pharaoh smote Gaza.
 \q The valleys shall also perish,
 \q2 And the table-land be destroyed,
 \q2 In accord with the word of Jehovah.
+\b
 \q
 \v 9 Give ye wings unto Moab,
 \q2 For fain would she fly away
@@ -6040,6 +6161,7 @@ Pharaoh smote Gaza.
 \q2 The work of Jehovah remissly;
 \q And cursed be he that keepeth
 \q2 His sword from (shedding) blood.
+\b
 \q
 \v 11 From his youth Moab been at ease,
 \q2 On his lees he hath quietly rested–
@@ -6053,6 +6175,7 @@ Pharaoh smote Gaza.
 \q And they shall tilt him over
 \q2 And empty out his vessels,
 \q2 And dash his jars in pieces.
+\b
 \q
 \v 13 And the hopes of Moab in Chemosh
 \q2 Shall be utterly disappointed,
@@ -6068,6 +6191,7 @@ Pharaoh smote Gaza.
 \q
 \v 16 The ruin of Moab is night at hand,
 \q2 Her misery hasteth swiftly.
+\b
 \q
 \v 17 Bemoan her, all ye her neighbours,
 \q2 All ye that know her name:
@@ -6078,6 +6202,7 @@ Pharaoh smote Gaza.
 \q2 Thou daughter that dwellest in Dibon;
 \q For the spoiler of Moab is come up against thee,
 \q2 Thy fortress he hath destroyed.
+\b
 \q
 \v 19 Stand by the way and spy,
 \q2 O thou that dwellest in Aroer;
@@ -6135,6 +6260,7 @@ her?
 \q2 They reached as far as Jazer;
 \q On thy summer fruits and their vintage
 \q2 Is the despoiler fallen.
+\b
 \q
 \v 33 Gladness and mirth are vanished
 \q2 From Moab's garden-land;
@@ -6150,6 +6276,7 @@ her?
 \v 35 I will cause, saith Jehovah, to vanish from Moab
 \q2 Him that offereth in the high place,
 \q2 And doth sacrifice to his god.
+\b
 \q
 \v 36 So my heart like a flute maketh moaning for Moab,
 \q2 My heart maketh moan for the men of Kir-heres;
@@ -6164,6 +6291,7 @@ her?
 \q2 Is universal wailing;
 \q For Moab I have shattered
 \q2 Like a vessel that one despiseth.
+\b
 \q
 \v 39 How broken is Moab! howl ye.
 \q2 How she turneth her back in shame!
@@ -6195,6 +6323,7 @@ her?
 \q2 A flame from the house of Sihon,
 \q Devouring the temples of Moab's head,
 \q2 And the crown of the head of the sons of tumult.
+\b
 \q
 \v 46 Woe unto thee, O Moab!
 \q2 The people of Chemosh is perished;
@@ -6222,6 +6351,7 @@ her?
 \q2 And with fire shall her daughters be burned;
 \q And Israel shall hold once more
 \q2 The land from which she was driven.
+\b
 \q
 \v 3 Howl, ye children of Ammon,
 \q2 Your capital is ruined;
@@ -6450,6 +6580,7 @@ the prophet.
 \q2 That shall desolate her land,
 \q So that none may dwell therein–
 \q2 Man, beast, are fled and gone.
+\b
 \q
 \v 4 In those days, at the time, saith Jehovah,
 \q2 The children of Israel shall come
@@ -6462,6 +6593,7 @@ the prophet.
 \q Saying, "Come, let us join Jehovah
 \q2 In a covenant everlasting,
 \q That never shall be forgotten."
+\b
 \q
 \v 6 Lost sheep have My people been,
 \q2 Their shepherds have led them astray,
@@ -6474,6 +6606,7 @@ the prophet.
 \q For they had offended Jehovah,
 \q2 The Fold, where righteousness dwelleth,
 \q2 Jehovah, the Hope of their fathers.
+\b
 \q
 \v 8 Flee ye from Babylon's midst,
 \q2 Get ye out from the land of Chaldea,
@@ -6488,6 +6621,7 @@ the prophet.
 \q
 \v 10 Chaldea shall be despoiled,
 \q2 All that spoil her shall have their fill.
+\b
 \q
 \v 11 Though ye rejoice and be glad,
 \q2 O ye that plunder My heritage;
@@ -6516,6 +6650,7 @@ the prophet.
 \q 'Tis the vengeance of Jehovah:
 \q2 Avenge yourselves upon her,
 \q2 Do to her as she hath done.
+\b
 \q
 \v 16 Root out of Babylon him that soweth,
 \q2 And him that wieldeth the sickle in harvest.
@@ -6528,6 +6663,7 @@ the prophet.
 \q First, the king of Assyria devoured him,
 \q2 And now at the last his bones
 \q2 Have been gnawed by the king of Babylon.
+\b
 \q
 \v 18 Therefore thus saith Jehovah of Hosts,
 \q2 The God of Israel: Behold,
@@ -6538,6 +6674,7 @@ the prophet.
 \q2 To pasture on Carmel and Bashan;
 \q On Ephraim's hills and in Gilead
 \q2 He shall fare to his heart's content.
+\b
 \q
 \v 20 In those days, at that time, saith Jehovah,
 \q2 Though Israel should be searched,
@@ -6550,6 +6687,7 @@ the prophet.
 \q2 And the people that dwell in Pekod;
 \q Slay and destroy them utterly,
 \q2 And do all I command, saith Jehovah.
+\b
 \q
 \v 22 Hark! the alarum of war,
 \q2 In Chaldea fell destruction.
@@ -6562,6 +6700,7 @@ the prophet.
 \q2 O Babylon, unaware:
 \q Thou art discovered and caught,
 \q2 Because thou hast challenged Jehovah.
+\b
 \q
 \v 25 Jehovah has opened His armoury,
 \q2 And brought forth His weapons of wrath;
@@ -6573,6 +6712,7 @@ the prophet.
 \q Pile her up like heaps of corn,
 \q2 And utterly detroy her;
 \q2 Let nothing of her be left.
+\b
 \q
 \v 27 Slay ye all her bullocks,
 \q2 Down let them go to the slaughter.
@@ -6583,6 +6723,7 @@ the prophet.
 \q2 Away from the land of Babylon
 \q To Zion, to tell how Jehovah,
 \q2 Our God, hath avenged His Temple.
+\b
 \q
 \v 29 Call against Babylon archers,
 \q2 All those that bend the bow;
@@ -6592,6 +6733,7 @@ the prophet.
 \q2 And deal with her as she dealt,
 \q For her insolence towards Jehovah,
 \q2 The Holy One of Israel.
+\b
 \q
 \v 30 In her squares shall her young men lie fallen,
 \q2 Her warriors all shall be silenced,
@@ -6618,6 +6760,7 @@ the prophet.
 \q He will surely defend their cause,
 \q2 That He may give rest to the earth,
 \q2 And disquiet the people of Babylon.
+\b
 \q
 \v 35 A sword upon the Chaldeans,
 \q2 Upon all the people of Babylon,
@@ -6638,6 +6781,7 @@ the prophet.
 \q2 And dried up shall they be!
 \q For she is a land of images,
 \q2 And with hideous (idols) they make themselves mad.
+\b
 \q
 \v 39 So wild cats and wolves shall dwell there,
 \q2 And there shall ostriches dwell;
@@ -6665,6 +6809,7 @@ the prophet.
 \q2 And he is all unstrung;
 \q Anguish hath seized upon him
 \q2 And pangs as of woman in travail.
+\b
 \q
 \v 44 Behold, as a lion comes up
 \q2 To the pastures of sheep from the jungle of Jordan,
@@ -6681,6 +6826,7 @@ the prophet.
 \q
 \v 46 At the shout, " She is taken," the earth doth tremble,
 \q2 And over the world their cry shall be heard.
+\b
 
 
 
@@ -6695,6 +6841,7 @@ the prophet.
 \q2 Who shall winnow and empty her land :
 \q Yea, woe shall beset her about
 \q2 In the day of her disaster.
+\b
 \q
 \v 3 Let the archer bend his bow,
 \q2 Stand erect in his coat of mail;
@@ -6703,6 +6850,7 @@ the prophet.
 \q
 \v 4 Let them fall down slain in the land of Chaldea,
 \q2 And stabbed upon her streets.
+\b
 \q
 \v 5c For their land is full of guilt
 \q2
@@ -6717,6 +6865,7 @@ the prophet.
 \q2 Lest her guilt bring destruction upon you.
 \q 'Tis Jehovah's day of revenge,
 \q2 With a recompense He is requiting her.
+\b
 \q
 \v 7 A golden cup is Babylon,
 \q2 That made the whole earth drunken:
@@ -6738,6 +6887,7 @@ the prophet.
 \v 10 Jehovah hath shown that the right was ours:
 \q2 Come, let us tell in Zion
 \q2 What Jehovah our God hath done.
+\b
 \q
 \v 11 Polish the arrows,
 \q2 Furbish the shields;
@@ -6746,6 +6896,7 @@ the prophet.
 \q He hath planned for the ruin of Babylon;
 \q2 For such is Jehovah's vengeance,
 \q2 The vengeance for His Temple.
+\b
 \q
 \v 12 Hoist ye the flag for the march
 \q2 Against the walls of Babylon;
@@ -6761,6 +6912,7 @@ the prophet.
 \v 14 Jehovah of Hosts hath most solemnly sworn:
 \q " I will fill thee with men who will swarm like locusts
 \q2 And lift up against thee a shout of triumph.
+\b
 \q
 \v 15 He created the earth by His power,
 \q2 He established the world by His wisdom,
@@ -6772,6 +6924,7 @@ the prophet.
 \q2 From the uttermost ends of the earth.
 \q Lightnings He made for the rain,
 \q2 And the wind He brings out of His storehouses.
+\b
 \q
 \v 17 How foolish is man with his knowledge!
 \q2 The goldsmith is shamed by his image;
@@ -6784,6 +6937,7 @@ the prophet.
 \v 19 Not such is the Portion of Jacob,
 \q2 His God is the Framer of all things;
 \q2 Jehovah of Hosts is His name.
+\b
 \q
 \v 20 My hammer of war hast thou been,
 \q2 With thee I have shattered the nations.
@@ -6815,6 +6969,7 @@ the prophet.
 \q2 And no foundation stones;
 \q But thou, saith Jehovah, shalt be
 \q2 A perpetual desolation.
+\b
 \q
 \v 27 Raise a banner upon the earth,
 \q2 Blow the trumpet among the nations;
@@ -6832,6 +6987,7 @@ the prophet.
 \q2 For Jehovah's design against Babylon standeth–
 \q To make the land of Babylon
 \q2 An uninhabited waste.
+\b
 \q
 \v 30 The warriors of Babylon cease fight,
 \q2 They stay within their fastnesses;
@@ -6844,6 +7000,7 @@ the prophet.
 \q2 And messenger to meet messenger,
 \q To tell the king of Babylon
 \q2 That on all sides his city is taken.
+\b
 \q
 \v 32 The ferries have been seized,
 \q2 The defences are burned with fire,
@@ -6855,6 +7012,7 @@ the prophet.
 \q2 Like a threshing-floor, when it is trodden;
 \q But yet a little while–
 \q2 And for her shall the harvest-time come.
+\b
 \q
 \v 34 Nebuchadrezzar, king of Babylon,
 \q2 Hath done me violent wrong:
@@ -6867,6 +7025,7 @@ the prophet.
 \q2 "The wrong done to me and my flesh be on Babylon!"
 \q Let Jerusalem say, "My blood
 \q2 Be on them that dwell in Chaldea!"
+\b
 \q
 \v 36 Thus therefore saith Jehovah:
 \q See! I will defend thy cause,
@@ -6889,6 +7048,7 @@ the prophet.
 \q
 \v 40 I will bring them down to the slaughter,
 \q2 Like the lambs or rams with goats.
+\b
 \q
 \v 41 How is Sheshach seized and taken,
 \q2 That was famous all over the world!
@@ -6897,6 +7057,7 @@ the prophet.
 \q
 \v 42 The sea came up upon Babylon,
 \q2 'Neath the roar of her billows she sank.
+\b
 \q
 \v 43 Her cities were turned to a waste,
 \q2 A dry and desert land:
@@ -6907,6 +7068,7 @@ the prophet.
 \q2 And make him disgorge what he swallowed.
 \q No more shall the nations stream to him;
 \q2 The wall of Babylon is fallen.
+\b
 \q
 \v 45 Forth from her midst, My people,
 \q2 Save every man his life
@@ -6918,6 +7080,7 @@ the prophet.
 \q2 And in the next another,
 \q And tyrant after tyrant
 \q2 Doeth violence in the earth.
+\b
 \q
 \v 47 See therefore, the days are coming,
 \q2 When I will punish the idols of Babylon,
@@ -6933,6 +7096,7 @@ the prophet.
 \q2 For Israel's sons that are slain,
 \q As for Babylon are fallen
 \q2 The slain of all the earth.
+\b
 \q
 \v 50 Ye that the sword have escaped,
 \q2 Depart ye, stand not still:
@@ -6943,6 +7107,7 @@ the prophet.
 \q2 And confusion hath covered our faces;
 \q For strangers are entered in
 \q2 To the Holy House of Jehovah."
+\b
 \q
 \v 52 See therefore, the days are coming
 \q2 When her images I will punish,
@@ -6973,6 +7138,7 @@ the prophet.
 \q2 They shall sleep their eternal sleep,
 \q To awake nevermore, saith the King,
 \q2 Whose name is Jehovah of Hosts.
+\b
 \q
 \v 58 Thus saith Jehovah of Hosts:
 \q Babylon's broad wall shall be razed to the ground,


### PR DESCRIPTION
Probably the biggest change here is splitting lines at verse breaks, as I mentioned in #327.
There were also some verse reordering fixups - McFadyen often relocates verses within the text.  In many cases these had been moved back, but only in a line-wise fashion - leaving the tails of verses unmoved.

Other changes include correcting some more typos, and fixing formatting - e.g. switching between prose and poetry and adding linebreaks, trying to bring more in line with the original [McFadyen text](https://archive.org/details/jeremiahinmodern00mcfauoft).
The changes including some use of `\pc` and `\qm`,`\qm2` tags.  They don't seem to be used elsewhere in the OEB, but I wanted to represent the original text as faithfully as I could, and I'm willing to accept they may have to be changed to something more conventional.